### PR TITLE
script: Make TrustedPromise::root return a RootedPromise.

### DIFF
--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -165,7 +165,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     task!(suspend_ok: move |cx| {
                         let base_context = base_context.root();
                         let context = context.root();
-                        let promise = trusted_promise.root();
+                        let promise = trusted_promise.root(cx);
                         promise.resolve_native(cx, &());
                         if base_context.State() != AudioContextState::Suspended {
                             base_context.set_state_attribute(AudioContextState::Suspended);
@@ -184,7 +184,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .task_manager()
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move |cx| {
-                        let promise = trusted_promise.root();
+                        let promise = trusted_promise.root(cx);
                         promise.reject_error(cx, Error::Type(c"Something went wrong".to_owned()));
                     }));
             },
@@ -221,7 +221,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     task!(suspend_ok: move |cx| {
                         let base_context = base_context.root();
                         let context = context.root();
-                        let promise = trusted_promise.root();
+                        let promise = trusted_promise.root(cx);
                         promise.resolve_native(cx, &());
                         if base_context.State() != AudioContextState::Closed {
                             base_context.set_state_attribute(AudioContextState::Closed);
@@ -240,7 +240,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .task_manager()
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move |cx| {
-                        let promise = trusted_promise.root();
+                        let promise = trusted_promise.root(cx);
                         promise.reject_error(cx, Error::Type(c"Something went wrong".to_owned()));
                     }));
             },

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -10,6 +10,7 @@ use std::cell::RefCell;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::rc::Rc;
 
+use js::context::JSContext;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::JSTracer;
 use rustc_hash::FxHashMap;
@@ -18,7 +19,7 @@ pub(crate) use script_bindings::refcounted::Trusted;
 use script_bindings::reflector::DomObject;
 use script_bindings::trace::trace_reflector;
 
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::tasks::task::TaskOnce;
 
 thread_local!(pub(super) static LIVE_PROMISE_REFERENCES: LivePromiseReferences =
@@ -76,7 +77,7 @@ impl TrustedPromise {
     /// Obtain a usable DOM Promise from a pinned `TrustedPromise` value. Fails if used on
     /// a different thread than the original value from which this `TrustedPromise` was
     /// obtained.
-    pub(crate) fn root(self) -> Rc<Promise> {
+    pub(crate) fn root(self, cx: &JSContext) -> RootedPromise {
         LIVE_PROMISE_REFERENCES.with(|live_references| {
             assert_eq!(
                 self.owner_thread,
@@ -93,6 +94,7 @@ impl TrustedPromise {
                         promises
                             .pop()
                             .expect("rooted promise list unexpectedly empty")
+                            .duplicate(cx)
                     };
                     if entry.get().is_empty() {
                         entry.remove();
@@ -109,7 +111,7 @@ impl TrustedPromise {
         let this = self;
         task!(reject_promise: move |cx| {
             debug!("Rejecting promise.");
-            this.root().reject_error(cx, error);
+            this.root(cx).reject_error(cx, error);
         })
     }
 
@@ -121,7 +123,7 @@ impl TrustedPromise {
         let this = self;
         task!(resolve_promise: move |cx| {
             debug!("Resolving promise.");
-            this.root().resolve_native(cx, &value);
+            this.root(cx).resolve_native(cx, &value);
         })
     }
 }

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -125,7 +125,11 @@ where
     T: AsyncBluetoothListener + DomObject,
 {
     fn response(&mut self, cx: &mut JSContext, response: BluetoothResponseResult) {
-        let promise = self.promise.take().expect("bt promise is missing").root(cx);
+        let promise = self
+            .promise
+            .take()
+            .expect("Bluetooth promise is missing")
+            .root(cx);
 
         // JSAutoRealm needs to be manually made.
         // Otherwise, Servo will crash.

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -125,8 +125,7 @@ where
     T: AsyncBluetoothListener + DomObject,
 {
     fn response(&mut self, cx: &mut JSContext, response: BluetoothResponseResult) {
-        let promise =
-            RootedPromise::from(self.promise.take().expect("bt promise is missing").root());
+        let promise = self.promise.take().expect("bt promise is missing").root(cx);
 
         // JSAutoRealm needs to be manually made.
         // Otherwise, Servo will crash.

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -325,7 +325,7 @@ impl ImageBitmap {
 
                 global_scope.task_manager().bitmap_task_source().queue(
                     task!(resolve_promise: move |cx| {
-                        let promise = trusted_promise.root();
+                        let promise = trusted_promise.root(cx);
                         let image_bitmap = trusted_image_bitmap.root();
 
                         promise.resolve_native(cx, &image_bitmap);
@@ -340,7 +340,7 @@ impl ImageBitmap {
 
             global_scope.task_manager().bitmap_task_source().queue(
                 task!(reject_promise: move |cx| {
-                    let promise = trusted_promise.root();
+                    let promise = trusted_promise.root(cx);
 
                     promise.reject_error(cx, Error::InvalidState(None));
                 }),

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -589,7 +589,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
             .canvas_blob_task_source()
             .queue(task!(convert_to_blob: move |cx| {
                 let this = trusted_this.root();
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
 
                 let mut encoded: Vec<u8> = vec![];
 

--- a/components/script/dom/clipboard/clipboard.rs
+++ b/components/script/dom/clipboard/clipboard.rs
@@ -147,7 +147,7 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
         // given realm’s global object, to perform the below steps:
         global.task_manager().clipboard_task_source().queue(
             task!(write_to_system_clipboard: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 let global = promise.global();
 
                 // Step 3.3.1 Let itemList be an empty sequence<Blob>.

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -537,7 +537,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
                 sheet.disallow_modification.set(false);
 
                 // Step 4.5. Resolve promise with sheet.
-                trusted_promise.root().resolve_native(cx, &sheet);
+                trusted_promise.root(cx).resolve_native(cx, &sheet);
             }));
 
         Ok(promise)

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -377,7 +377,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
             .task_manager()
             .font_loading_task_source()
             .queue(task!(resolve_font_face_set_load_task: move |cx| {
-                let load_promise = trusted_load_promise.root().duplicate(cx);
+                let load_promise = trusted_load_promise.root(cx);
                 let this = trusted_this.root();
 
                 // This will need adjustments once FontFaceSet is exposed to workers.

--- a/components/script/dom/event/promiserejectionevent.rs
+++ b/components/script/dom/event/promiserejectionevent.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
@@ -48,7 +46,7 @@ impl PromiseRejectionEvent {
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
-        promise: Rc<Promise>,
+        promise: &Promise,
         reason: HandleValue,
     ) -> DomRoot<Self> {
         Self::new_with_proto(

--- a/components/script/dom/fullscreen/lib.rs
+++ b/components/script/dom/fullscreen/lib.rs
@@ -290,7 +290,7 @@ impl TaskOnce for ElementPerformFullscreenEnter {
     /// Step 9-14 of <https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen>
     fn run_once(self, cx: &mut js::context::JSContext) {
         let element = self.element.root();
-        let promise = self.promise.root();
+        let promise = self.promise.root(cx);
         let document = element.owner_document();
 
         // Step 9
@@ -368,6 +368,6 @@ impl TaskOnce for ElementPerformFullscreenExit {
 
         // Step 16
         // > Resolve promise with undefined.
-        self.promise.root().resolve_native(cx, &());
+        self.promise.root(cx).resolve_native(cx, &());
     }
 }

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -200,7 +200,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
             let trusted_promise = TrustedPromise::new(promise);
             self.global().task_manager().gamepad_task_source().queue(
                 task!(preempt_promise: move |cx| {
-                    let promise = trusted_promise.root();
+                    let promise = trusted_promise.root(cx);
                     let message = DOMString::from_static("preempted");
                     promise.resolve_native(cx, &message);
                 }),
@@ -264,7 +264,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
             let trusted_promise = TrustedPromise::new(promise);
             self.global().task_manager().gamepad_task_source().queue(
                 task!(preempt_promise: move |cx| {
-                    let promise = trusted_promise.root();
+                    let promise = trusted_promise.root(cx);
                     let message = DOMString::from_static("preempted");
                     promise.resolve_native(cx, &message);
                 }),
@@ -331,7 +331,7 @@ impl GamepadHapticActuator {
                         warn!("Mismatched sequence/reset sequence ids: {} != {}", sequence_id, reset_sequence_id);
                         return;
                     }
-                    let promise = trusted_promise.root();
+                    let promise = trusted_promise.root(cx);
                     let message = DOMString::from_static("complete");
                     promise.resolve_native(cx, &message);
                 })

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -123,7 +123,7 @@ use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::performance::performance::Performance;
 use crate::dom::performance::performanceentry::EntryType;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::readablestream::{CrossRealmTransformReadable, ReadableStream};
 use crate::dom::script_execution::ScriptOptions;
 use crate::dom::serviceworker::ServiceWorker;
@@ -406,7 +406,7 @@ struct BroadcastListener {
 }
 
 type FileListenerCallback =
-    Box<dyn Fn(&mut js::context::JSContext, Rc<Promise>, Fallible<Vec<u8>>) + Send>;
+    Box<dyn Fn(&mut js::context::JSContext, &RootedPromise, Fallible<Vec<u8>>) + Send>;
 
 /// A wrapper for the handling of file data received by the ipc router
 struct FileListener {
@@ -675,9 +675,9 @@ impl FileListener {
                 Some(FileListenerState::Receiving(bytes, target)) => match target {
                     FileListenerTarget::Promise(trusted_promise, callback) => {
                         let task = task!(resolve_promise: move |cx| {
-                            let promise = trusted_promise.root();
+                            let promise = trusted_promise.root(cx);
                             let mut realm = enter_auto_realm(cx, &*promise.global());
-                            callback(&mut realm, promise, Ok(bytes));
+                            callback(&mut realm, &promise, Ok(bytes));
                         });
 
                         self.task_source.queue(task);
@@ -703,9 +703,9 @@ impl FileListener {
                     match target {
                         FileListenerTarget::Promise(trusted_promise, callback) => {
                             self.task_source.queue(task!(reject_promise: move |cx| {
-                                let promise = trusted_promise.root();
+                                let promise = trusted_promise.root(cx);
                                 let mut realm = enter_auto_realm(cx, &*promise.global());
-                                callback(&mut realm, promise, error);
+                                callback(&mut realm, &promise, error);
                             }));
                         },
                         FileListenerTarget::Stream(trusted_stream) => {

--- a/components/script/dom/html/embedded_content/htmlimageelement.rs
+++ b/components/script/dom/html/embedded_content/htmlimageelement.rs
@@ -1086,7 +1086,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(fulfill_image_decode_promises: move |cx| {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().resolve_native(cx, &());
+                    trusted_promise.root(cx).resolve_native(cx, &());
                 }
             }));
     }
@@ -1113,7 +1113,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(reject_image_decode_promises: move |cx| {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().reject_error(cx, Error::Encoding(Some("Image could not be decoded".into())));
+                    trusted_promise.root(cx).reject_error(cx, Error::Encoding(Some("Image could not be decoded".into())));
                 }
             }));
     }

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -671,7 +671,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
 
             // Step 4.4: Queue a database task to resolve p with result.
             task_source.queue(task!(set_request_result_to_database: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 match result {
                     Err(err) => {
                         let error = map_backend_error_to_dom_error(err);

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -243,10 +243,7 @@ impl Promise {
         promise
     }
 
-    pub(crate) fn new_with_js_promise_rooted(
-        cx: &JSContext,
-        obj: HandleObject,
-    ) -> RootedPromise {
+    pub(crate) fn new_with_js_promise_rooted(cx: &JSContext, obj: HandleObject) -> RootedPromise {
         RootedPromise(Self::new_with_js_promise(cx, obj))
     }
 

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -165,12 +165,12 @@ pub(crate) struct Promise {
 
 /// Private helper to enable adding new methods to `Rc<Promise>`.
 trait PromiseHelper {
-    fn initialize(&self, cx: &mut JSContext);
+    fn initialize(&self, cx: &JSContext);
 }
 
 impl PromiseHelper for Rc<Promise> {
     #[expect(unsafe_code)]
-    fn initialize(&self, cx: &mut JSContext) {
+    fn initialize(&self, cx: &JSContext) {
         let obj = self.reflector().get_jsobject();
         self.permanent_js_root.set(ObjectValue(*obj));
         unsafe {
@@ -221,13 +221,13 @@ impl Promise {
         RootedPromise(Self::new_in_realm(current_realm))
     }
 
-    pub(crate) fn duplicate(&self, cx: &mut JSContext) -> RootedPromise {
+    pub(crate) fn duplicate(&self, cx: &JSContext) -> RootedPromise {
         Promise::new_with_js_promise_rooted(cx, self.reflector().get_jsobject())
     }
 
     #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn new_with_js_promise(cx: &mut JSContext, obj: HandleObject) -> Rc<Promise> {
+    pub(crate) fn new_with_js_promise(cx: &JSContext, obj: HandleObject) -> Rc<Promise> {
         unsafe {
             assert!(IsPromiseObject(obj));
         }
@@ -244,7 +244,7 @@ impl Promise {
     }
 
     pub(crate) fn new_with_js_promise_rooted(
-        cx: &mut JSContext,
+        cx: &JSContext,
         obj: HandleObject,
     ) -> RootedPromise {
         RootedPromise(Self::new_with_js_promise(cx, obj))

--- a/components/script/dom/serviceworker/notification.rs
+++ b/components/script/dom/serviceworker/notification.rs
@@ -421,7 +421,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
 
         global.task_manager().dom_manipulation_task_source().queue(
             task!(request_permission: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 let global = promise.global();
 
                 // Step 3.2.1: If deprecatedCallback is given,

--- a/components/script/dom/storage/storagemanager.rs
+++ b/components/script/dom/storage/storagemanager.rs
@@ -73,7 +73,7 @@ impl StorageManagerBooleanResponseHandler {
 
         self.task_source
             .queue(task!(storage_manager_boolean_response: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 match result {
                     Ok(value) => promise.resolve_native(cx, &value),
                     Err(message) => promise.reject_error(cx, StorageManager::type_error_from_string(message)),
@@ -103,7 +103,7 @@ impl StorageManagerEstimateResponseHandler {
 
         self.task_source
             .queue(task!(storage_manager_estimate_response: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 match result {
                     Ok((usage, quota)) => {
                         let mut estimate = StorageEstimate::empty();

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1196,7 +1196,7 @@ pub(crate) struct TestBindingCallback {
 
 impl TestBindingCallback {
     pub(crate) fn invoke(self, cx: &mut JSContext) {
-        self.promise.root().resolve_native(cx, &self.value);
+        self.promise.root(cx).resolve_native(cx, &self.value);
     }
 }
 

--- a/components/script/dom/testing/testutils.rs
+++ b/components/script/dom/testing/testutils.rs
@@ -35,7 +35,7 @@ impl TestUtilsMethods<crate::DomTypeHolder> for TestUtils {
             unsafe {
                 JS_GC(cx.raw_cx(), GCReason::DOM_TESTUTILS);
             }
-            let promise = trusted.root();
+            let promise = trusted.root(cx);
             promise.resolve_native(cx, &());
         });
 

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -81,7 +81,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::utils::set_dictionary_property;
 use crate::dom::cryptokey::{CryptoKey, CryptoKeyOrCryptoKeyPair};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 
 // Named elliptic curves
 const NAMED_CURVE_P256: &str = "P-256";
@@ -218,13 +218,13 @@ impl SubtleCrypto {
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with the result of creating an ArrayBuffer in realm, containing data. If it fails
     /// to create buffer source, reject promise with a JSFailedError.
-    fn resolve_promise_with_data(&self, promise: Rc<Promise>, data: Zeroizing<Vec<u8>>) {
-        let trusted_promise = TrustedPromise::new(promise);
+    fn resolve_promise_with_data(&self, promise: &RootedPromise, data: Zeroizing<Vec<u8>>) {
+        let trusted_promise = TrustedPromise::from(promise);
         self.global()
             .task_manager()
             .crypto_task_source()
             .queue(task!(resolve_data: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
 
                 rooted!(&in(cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
                 match create_buffer_source::<ArrayBufferU8>(cx,
@@ -243,7 +243,7 @@ impl SubtleCrypto {
     fn resolve_promise_with_jwk(
         &self,
         cx: &mut js::context::JSContext,
-        promise: Rc<Promise>,
+        promise: &RootedPromise,
         jwk: Box<JsonWebKey>,
     ) {
         // NOTE: Serialize the JsonWebKey dictionary by stringifying it, in order to pass it to
@@ -257,13 +257,13 @@ impl SubtleCrypto {
         };
 
         let trusted_subtle = Trusted::new(self);
-        let trusted_promise = TrustedPromise::new(promise);
+        let trusted_promise = TrustedPromise::from(promise);
         self.global()
             .task_manager()
             .crypto_task_source()
             .queue(task!(resolve_jwk: move |cx| {
                 let subtle = trusted_subtle.root();
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
 
                 match JsonWebKey::parse(cx, stringified_jwk.as_bytes()) {
                     Ok(jwk) => {
@@ -273,7 +273,7 @@ impl SubtleCrypto {
                         promise.resolve_native(cx, &*object);
                     },
                     Err(error) => {
-                        subtle.reject_promise_with_error(promise, error);
+                        subtle.reject_promise_with_error(&promise, error);
                         return;
                     },
                 }
@@ -282,25 +282,25 @@ impl SubtleCrypto {
 
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with a CryptoKey.
-    fn resolve_promise_with_key(&self, promise: Rc<Promise>, key: &CryptoKey) {
+    fn resolve_promise_with_key(&self, promise: &RootedPromise, key: &CryptoKey) {
         let trusted_key = Trusted::new(key);
-        let trusted_promise = TrustedPromise::new(promise);
+        let trusted_promise = TrustedPromise::from(promise);
         self.global()
             .task_manager()
             .crypto_task_source()
             .queue(task!(resolve_key: move |cx| {
                 let key = trusted_key.root();
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 promise.resolve_native(cx, &key);
             }));
     }
 
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with a CryptoKeyPair.
-    fn resolve_promise_with_key_pair(&self, promise: Rc<Promise>, key_pair: CryptoKeyPair) {
+    fn resolve_promise_with_key_pair(&self, promise: &RootedPromise, key_pair: CryptoKeyPair) {
         let trusted_private_key = key_pair.privateKey.map(|key| Trusted::new(&*key));
         let trusted_public_key = key_pair.publicKey.map(|key| Trusted::new(&*key));
-        let trusted_promise = TrustedPromise::new(promise);
+        let trusted_promise = TrustedPromise::from(promise);
         self.global()
             .task_manager()
             .crypto_task_source()
@@ -309,33 +309,33 @@ impl SubtleCrypto {
                     privateKey: trusted_private_key.map(|trusted_key| trusted_key.root()),
                     publicKey: trusted_public_key.map(|trusted_key| trusted_key.root()),
                 };
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 promise.resolve_native(cx, &key_pair);
             }));
     }
 
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with a bool value.
-    fn resolve_promise_with_bool(&self, promise: Rc<Promise>, result: bool) {
-        let trusted_promise = TrustedPromise::new(promise);
+    fn resolve_promise_with_bool(&self, promise: &RootedPromise, result: bool) {
+        let trusted_promise = TrustedPromise::from(promise);
         self.global()
             .task_manager()
             .crypto_task_source()
             .queue(task!(resolve_bool: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 promise.resolve_native(cx, &result);
             }));
     }
 
     /// Queue a global task on the crypto task source, given realm's global object, to reject
     /// promise with an error.
-    fn reject_promise_with_error(&self, promise: Rc<Promise>, error: Error) {
-        let trusted_promise = TrustedPromise::new(promise);
+    fn reject_promise_with_error(&self, promise: &RootedPromise, error: Error) {
+        let trusted_promise = TrustedPromise::from(promise);
         self.global()
             .task_manager()
             .crypto_task_source()
             .queue(task!(reject_error: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 promise.reject_error(cx, error);
             }));
     }
@@ -345,13 +345,13 @@ impl SubtleCrypto {
     /// defined by [WebIDL].
     fn resolve_promise_with_encapsulated_key(
         &self,
-        promise: Rc<Promise>,
+        promise: &RootedPromise,
         encapsulated_key: EncapsulatedKey,
     ) {
-        let trusted_promise = TrustedPromise::new(promise);
+        let trusted_promise = TrustedPromise::from(promise);
         self.global().task_manager().crypto_task_source().queue(
             task!(resolve_encapsulated_key: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 promise.resolve_native(cx, &encapsulated_key);
             }),
         );
@@ -362,13 +362,13 @@ impl SubtleCrypto {
     /// defined by [WebIDL].
     fn resolve_promise_with_encapsulated_bits(
         &self,
-        promise: Rc<Promise>,
+        promise: &RootedPromise,
         encapsulated_bits: EncapsulatedBits,
     ) {
-        let trusted_promise = TrustedPromise::new(promise);
+        let trusted_promise = TrustedPromise::from(promise);
         self.global().task_manager().crypto_task_source().queue(
             task!(resolve_encapsulated_bits: move |cx| {
-                let promise = trusted_promise.root();
+                let promise = trusted_promise.root(cx);
                 promise.resolve_native(cx, &encapsulated_bits);
             }),
         );
@@ -415,9 +415,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(encrypt: move || {
+            .queue(task!(encrypt: move |cx| {
                 let subtle = this.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let key = trusted_key.root();
 
                 // Step 8. If the following steps or referenced procedures say to throw an error,
@@ -499,9 +499,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(decrypt: move || {
+            .queue(task!(decrypt: move |cx| {
                 let subtle = this.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let key = trusted_key.root();
 
                 // Step 8. If the following steps or referenced procedures say to throw an error,
@@ -583,9 +583,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(sign: move || {
+            .queue(task!(sign: move |cx| {
                 let subtle = this.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let key = trusted_key.root();
 
                 // Step 8. If the following steps or referenced procedures say to throw an error,
@@ -671,9 +671,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(sign: move || {
+            .queue(task!(sign: move |cx| {
                 let subtle = this.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let key = trusted_key.root();
 
                 // Step 9. If the following steps or referenced procedures say to throw an error,
@@ -750,9 +750,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(digest_: move || {
+            .queue(task!(digest_: move |cx| {
                 let subtle = this.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 8. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -814,7 +814,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             .dom_manipulation_task_source()
             .queue(task!(generate_key: move |cx| {
                 let subtle = trusted_subtle.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 7. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -947,7 +947,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             task!(derive_key: move |cx| {
                 let subtle = trusted_subtle.root();
                 let base_key = trusted_base_key.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 11. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -1067,10 +1067,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(import_key: move || {
+            .queue(task!(import_key: move |cx| {
                 let subtle = trsuted_subtle.root();
                 let base_key = trusted_base_key.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 7. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -1210,7 +1210,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             .dom_manipulation_task_source()
             .queue(task!(import_key: move |cx| {
                 let subtle = this.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 8. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -1276,7 +1276,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             .dom_manipulation_task_source()
             .queue(task!(export_key: move |cx| {
                 let subtle = trusted_subtle.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let key = trusted_key.root();
 
                 // Step 5. If the following steps or referenced procedures say to throw an error,
@@ -1394,7 +1394,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 let subtle = trusted_subtle.root();
                 let key = trusted_key.root();
                 let wrapping_key = trusted_wrapping_key.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 8. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -1585,7 +1585,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             task!(unwrap_key: move |cx| {
                 let subtle = trusted_subtle.root();
                 let unwrapping_key = trusted_unwrapping_key.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 11. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -1753,7 +1753,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             task!(encapsulate_keys: move |cx| {
                 let subtle = trusted_subtle.root();
                 let encapsulation_key = trusted_encapsulated_key.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 9. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -1879,10 +1879,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         let trusted_encapsulation_key = Trusted::new(encapsulation_key);
         let trusted_promise = TrustedPromise::new(promise.clone());
         self.global().task_manager().dom_manipulation_task_source().queue(
-            task!(derive_key: move || {
+            task!(derive_key: move |cx| {
                 let subtle = trusted_subtle.root();
                 let encapsulation_key = trusted_encapsulation_key.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
 
                 // Step 7. If the following steps or referenced procedures say to throw an error,
                 // queue a global task on the crypto task source, given realm's global object, to
@@ -1995,7 +1995,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             .dom_manipulation_task_source()
             .queue(task!(decapsulate_key: move |cx| {
                 let subtle = trusted_subtle.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let decapsulation_key = trusted_decapsulation_key.root();
 
                 // Step 10. If the following steps or referenced procedures say to throw an error,
@@ -2113,9 +2113,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(decapsulate_bits: move || {
+            .queue(task!(decapsulate_bits: move |cx| {
                 let subtle = trusted_subtle.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let decapsulation_key = trusted_decapsulation_key.root();
 
                 // Step 8. If the following steps or referenced procedures say to throw an error,
@@ -2212,7 +2212,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             .dom_manipulation_task_source()
             .queue(task!(get_public_key: move |cx| {
                 let subtle = trusted_subtle.root();
-                let promise = trusted_promise.root();
+                let promise = &trusted_promise.root(cx);
                 let key = trusted_key.root();
 
                 // Step 7. If the following steps or referenced procedures say to throw an error,

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -671,7 +671,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                             desc.sdp,
                         );
                         this.local_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(current_realm, &())
+                        trusted_promise.root(current_realm).resolve_native(current_realm, &())
                     }));
                 }),
             );
@@ -714,7 +714,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                             desc.sdp,
                         );
                         this.remote_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(current_realm, &())
+                        trusted_promise.root(current_realm).resolve_native(current_realm, &())
                     }));
                 }),
             );

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -31,7 +31,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::gamepad::Gamepad;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::window::Window;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrtest::XRTest;
@@ -254,7 +254,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     return;
                 };
                 task_source.queue(task!(request_session: move |cx| {
-                    this.root().session_obtained(cx, message, trusted.root(), mode, frame_receiver);
+                    this.root().session_obtained(cx, message, &trusted.root(cx), mode, frame_receiver);
                 }));
             }),
         );
@@ -275,7 +275,7 @@ impl XRSystem {
         &self,
         cx: &mut JSContext,
         response: Result<Session, XRError>,
-        promise: Rc<Promise>,
+        promise: &RootedPromise,
         mode: XRSessionMode,
         frame_receiver: IpcReceiver<Frame>,
     ) {

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -54,7 +54,7 @@ impl XRTest {
         response: Result<GenericSender<MockDeviceMsg>, XRError>,
         trusted: TrustedPromise,
     ) {
-        let promise = trusted.root();
+        let promise = trusted.root(cx);
         if let Ok(sender) = response {
             let device = FakeXRDevice::new(cx, &self.global(), sender);
             self.devices_connected

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -173,7 +173,7 @@ use crate::dom::navigator::Navigator;
 use crate::dom::node::{Node, NodeDamage, NodeTraits, from_untrusted_node_address};
 use crate::dom::performance::performance::Performance;
 use crate::dom::performanceresourcetiming::InitiatorType;
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 use crate::dom::reporting::reportingendpoint::{ReportingEndpoint, SendReportsToEndpoints};
 use crate::dom::reporting::reportingobserver::ReportingObserver;
 use crate::dom::selection::Selection;
@@ -1720,7 +1720,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         realm: &mut CurrentRealm,
         image: ImageBitmapSource,
         options: &ImageBitmapOptions,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         ImageBitmap::create_image_bitmap(
             self.as_global_scope(),
             image,
@@ -1731,6 +1731,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             options,
             realm,
         )
+        .duplicate(realm)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-createimagebitmap>
@@ -1743,7 +1744,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         sw: i32,
         sh: i32,
         options: &ImageBitmapOptions,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         ImageBitmap::create_image_bitmap(
             self.as_global_scope(),
             image,
@@ -1754,6 +1755,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             options,
             realm,
         )
+        .duplicate(realm)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window>
@@ -2234,7 +2236,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         realm: &mut CurrentRealm,
         input: RequestOrUSVString,
         init: RootedTraceableBox<RequestInit>,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         fetch::Fetch(self.upcast(), input, init, realm)
     }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -78,7 +78,7 @@ use crate::dom::htmlscriptelement::{SCRIPT_JS_MIMES, Script};
 use crate::dom::idbfactory::IDBFactory;
 use crate::dom::performance::performance::Performance;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
-use crate::dom::promise::Promise;
+use crate::dom::promise::RootedPromise;
 use crate::dom::reporting::reportingendpoint::{ReportingEndpoint, SendReportsToEndpoints};
 use crate::dom::reporting::reportingobserver::ReportingObserver;
 use crate::dom::script_execution::ScriptOptions;
@@ -1012,8 +1012,9 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
         realm: &mut CurrentRealm,
         image: ImageBitmapSource,
         options: &ImageBitmapOptions,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         ImageBitmap::create_image_bitmap(self.upcast(), image, 0, 0, None, None, options, realm)
+            .duplicate(realm)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-createimagebitmap>
@@ -1026,7 +1027,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
         sw: i32,
         sh: i32,
         options: &ImageBitmapOptions,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         ImageBitmap::create_image_bitmap(
             self.upcast(),
             image,
@@ -1037,6 +1038,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             options,
             realm,
         )
+        .duplicate(realm)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-global-fetch>
@@ -1045,7 +1047,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
         realm: &mut CurrentRealm,
         input: RequestOrUSVString,
         init: RootedTraceableBox<RequestInit>,
-    ) -> Rc<Promise> {
+    ) -> RootedPromise {
         Fetch(self.upcast(), input, init, realm)
     }
 

--- a/components/script/fetch/fetch.rs
+++ b/components/script/fetch/fetch.rs
@@ -51,7 +51,7 @@ use crate::dom::fetchlaterresult::FetchLaterResult;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::Guard;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
-use crate::dom::promise::Promise;
+use crate::dom::promise::{Promise, RootedPromise};
 use crate::dom::request::Request;
 use crate::dom::response::Response;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
@@ -332,7 +332,7 @@ fn request_init_from_request(request: NetTraitsRequest, global: &GlobalScope) ->
 
 /// <https://fetch.spec.whatwg.org/#abort-fetch>
 fn abort_fetch_call(
-    promise: Rc<Promise>,
+    promise: &RootedPromise,
     request: &Request,
     response_object: Option<&Response>,
     abort_reason: HandleValue,
@@ -367,9 +367,9 @@ pub(crate) fn Fetch(
     input: RequestInfo,
     init: RootedTraceableBox<RequestInit>,
     cx: &mut CurrentRealm,
-) -> Rc<Promise> {
+) -> RootedPromise {
     // Step 1. Let p be a new promise.
-    let promise = Promise::new_in_realm(cx);
+    let promise = Promise::new_in_realm_rooted(cx);
 
     // Step 7. Let responseObject be null.
     // NOTE: We do initialize the object earlier so we can use it to track errors.
@@ -396,7 +396,7 @@ pub(crate) fn Fetch(
         rooted!(&in(cx) let mut abort_reason = UndefinedValue());
         signal.Reason(abort_reason.handle_mut());
         abort_fetch_call(
-            promise.clone(),
+            &promise,
             &request_object,
             None,
             abort_reason.handle(),
@@ -424,7 +424,7 @@ pub(crate) fn Fetch(
     // Step 9. Let locallyAborted be false.
     // Step 10. Let controller be null.
     let fetch_context = FetchContext {
-        fetch_promise: Some(TrustedPromise::new(promise.clone())),
+        fetch_promise: Some(TrustedPromise::from(&promise)),
         response_object: Trusted::new(&*response),
         request: Trusted::new(&*request_object),
         global: Trusted::new(global),
@@ -661,9 +661,9 @@ impl FetchContext {
             .fetch_promise
             .take()
             .expect("fetch promise is missing")
-            .root();
+            .root(cx);
         abort_fetch_call(
-            promise,
+            &promise,
             &request,
             Some(&self.response_object.root()),
             abort_reason,
@@ -693,7 +693,7 @@ impl FetchResponseListener for FetchContext {
             .fetch_promise
             .take()
             .expect("fetch promise is missing")
-            .root();
+            .root(cx);
 
         let mut realm = enter_auto_realm(cx, &*promise);
         let cx = &mut realm.current_realm();
@@ -702,7 +702,7 @@ impl FetchResponseListener for FetchContext {
             // p with a TypeError and abort these steps.
             Err(error) => {
                 promise.reject_error(cx, Error::Type(cformat!("Network error: {:?}", error)));
-                self.fetch_promise = Some(TrustedPromise::new(promise));
+                self.fetch_promise = Some(TrustedPromise::from(&promise));
                 let response = self.response_object.root();
                 response.set_type(cx, DOMResponseType::Error);
                 response.error_stream(cx, Error::Type(c"Network error occurred".to_owned()));
@@ -743,7 +743,7 @@ impl FetchResponseListener for FetchContext {
 
         // Step 12.5. Resolve p with responseObject.
         promise.resolve_native(cx, &self.response_object.root());
-        self.fetch_promise = Some(TrustedPromise::new(promise));
+        self.fetch_promise = Some(TrustedPromise::from(&promise));
     }
 
     fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Bytes) {

--- a/components/script/routed_promise.rs
+++ b/components/script/routed_promise.rs
@@ -29,7 +29,7 @@ impl<R: Serialize + DeserializeOwned + Send, T: RoutedPromiseListener<R> + DomOb
     RoutedPromiseContext<R, T>
 {
     fn response(self, cx: &mut JSContext, response: R) {
-        let promise = RootedPromise::from(self.trusted.root());
+        let promise = self.trusted.root(cx);
         self.receiver.root().handle_response(cx, response, &promise);
     }
 }

--- a/components/script/runtime/script_runtime.rs
+++ b/components/script/runtime/script_runtime.rs
@@ -301,7 +301,7 @@ unsafe extern "C" fn promise_rejection_tracker(
                 global.task_manager().dom_manipulation_task_source().queue(
                 task!(rejection_handled_event: move |cx| {
                     let target = target.root();
-                    let root_promise = trusted_promise.root();
+                    let root_promise = trusted_promise.root(cx);
 
                     rooted!(&in(cx) let mut reason = UndefinedValue());
                     unsafe {
@@ -314,7 +314,7 @@ unsafe extern "C" fn promise_rejection_tracker(
                         atom!("rejectionhandled"),
                         EventBubbles::DoesNotBubble,
                         EventCancelable::Cancelable,
-                        root_promise,
+                        &root_promise,
                         reason.handle(),
                     );
 
@@ -479,7 +479,7 @@ pub(crate) fn notify_about_rejected_promises(cx: &mut JSContext, global: &Global
 
             // Step 4.1 For each promise p of list:
             for promise in uncaught_rejections {
-                let promise = promise.root();
+                let promise = promise.root(cx);
 
                 // 4.1.1 If p.[[PromiseIsHandled]] is true, then continue.
                 if promise.get_promise_is_handled() {
@@ -505,7 +505,7 @@ pub(crate) fn notify_about_rejected_promises(cx: &mut JSContext, global: &Global
                     atom!("unhandledrejection"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::Cancelable,
-                    promise.clone(),
+                    &promise,
                     reason.handle(),
                 );
                 event.upcast::<Event>().fire(cx, &target);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1458,7 +1458,6 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'useRcPromise': True,
     'additionalTraits': ['crate::interfaces::WindowHelpers', 'crate::interfaces::HasOrigin'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
@@ -1520,7 +1519,6 @@ DOMInterfaces = {
 },
 
 'WorkerGlobalScope': {
-    'useRcPromise': True,
     'cx': ['Caches', 'Crypto', 'ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone', 'IndexedDB', 'QueueMicrotask', 'Location', 'Navigator', 'Performance'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'Fetch'],
 },


### PR DESCRIPTION
This is a boring mechanical change that ensures that the promise that comes from rooting a trusted promise is always rooted. It's an important prerequisite to the work to fix #47749, when we need to start being careful about where we get our `Rc<Promise>` values from and whether they're rooted or not.

Testing: Existing tests suffice.
Part of https://github.com/servo/servo/issues/47747
Part of #47749