### PR TITLE
script: Do not treat traced promise objects as GC roots.

### DIFF
--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -220,7 +220,8 @@ impl BaseAudioContext {
             .borrow_mut()
             .pop_front()
             .map(|(promises, result)| {
-                let promises: Vec<RootedPromise> = promises.iter().map(|promise| promise.root(cx)).collect();
+                let promises: Vec<RootedPromise> =
+                    promises.iter().map(|promise| promise.root(cx)).collect();
                 (promises, result)
             })
             .expect("there should be at least one list of in flight resume promises");

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -220,7 +220,7 @@ impl BaseAudioContext {
             .borrow_mut()
             .pop_front()
             .map(|(promises, result)| {
-                let promises: Vec<RootedPromise> = promises.iter().map(|p| p.root(cx)).collect();
+                let promises: Vec<RootedPromise> = promises.iter().map(|promise| promise.root(cx)).collect();
                 (promises, result)
             })
             .expect("there should be at least one list of in flight resume promises");

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -220,7 +220,7 @@ impl BaseAudioContext {
             .borrow_mut()
             .pop_front()
             .map(|(promises, result)| {
-                let promises: Vec<RootedPromise> = promises.iter().map(|p| p.root()).collect();
+                let promises: Vec<RootedPromise> = promises.iter().map(|p| p.root(cx)).collect();
                 (promises, result)
             })
             .expect("there should be at least one list of in flight resume promises");
@@ -593,7 +593,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                                 .decode_resolvers
                                 .safe_borrow_mut(cx.no_gc())
                                 .remove(&uuid_)
-                                .map(|resolver| (resolver.promise.root(), resolver.success_callback))
+                                .map(|resolver| (resolver.promise.root(cx), resolver.success_callback))
                                 .expect("resolver should exist");
 
                             if let Some(callback) = success_callback {
@@ -609,7 +609,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                                 .decode_resolvers
                                 .safe_borrow_mut(cx.no_gc())
                                 .remove(&uuid)
-                                .map(|resolver| (resolver.promise.root(), resolver.error_callback))
+                                .map(|resolver| (resolver.promise.root(cx), resolver.error_callback))
                                 .expect("resolver should exist");
 
                             if let Some(callback) = error_callback {

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -655,10 +655,10 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         // other than "unloaded", return font face’s [[FontStatusPromise]] and abort these
         // steps.
         let Some(sources) = self.urls.borrow_mut().take() else {
-            return self.font_status_promise.root();
+            return self.font_status_promise.root(cx);
         };
         if self.status.get() != FontFaceLoadStatus::Unloaded {
-            return self.font_status_promise.root();
+            return self.font_status_promise.root(cx);
         }
 
         let global = self.global();
@@ -740,12 +740,12 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
             font_face_set.handle_font_face_status_changed(cx, self);
         }
 
-        self.font_status_promise.root()
+        self.font_status_promise.root(cx)
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontface-loaded>
-    fn Loaded(&self) -> RootedPromise {
-        self.font_status_promise.root()
+    fn Loaded(&self, cx: &JSContext) -> RootedPromise {
+        self.font_status_promise.root(cx)
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#font-face-constructor>

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -281,7 +281,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
             // re-initializing document.fonts.ready.
             self.flush_author_font_set(cx);
         }
-        self.promise.borrow().root()
+        self.promise.borrow().root(cx)
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-add>

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -52,8 +52,14 @@ use crate::event_loop::script_thread::ScriptThread;
 use crate::realms::enter_auto_realm;
 use crate::runtime::job_queue::MicrotaskRunnable;
 
+/// A reference to a Promise object, treated as a GC root. The Promise will not
+/// be collected by the GC before this RootedPromise is dropped..
+/// RootedPromise must never be stored inside of structs that are traced during a GC
+/// operation (such as reflected DOM objects) because it can lead to permanent
+/// GC cycles that prevent memory from being reclaimed.
 #[derive(Clone)]
-pub(crate) struct RootedPromise(Rc<Promise>);
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+pub(crate) struct RootedPromise(Rc<(Promise, PermanentRoot)>);
 
 impl StackRootPromiseHelpers<crate::DomTypeHolder> for RootedPromise {
     type HeapTraced = TracedPromise;
@@ -65,31 +71,20 @@ impl StackRootPromiseHelpers<crate::DomTypeHolder> for RootedPromise {
 impl Deref for RootedPromise {
     type Target = Promise;
     fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<Rc<Promise>> for RootedPromise {
-    fn from(promise: Rc<Promise>) -> Self {
-        RootedPromise(promise)
-    }
-}
-
-impl From<RootedPromise> for Rc<Promise> {
-    fn from(root: RootedPromise) -> Self {
-        root.0
+        &self.0.0
     }
 }
 
 impl RootedPromise {
+    /// Obtain a TracedPromise object that references the same underlying Promise.
     pub(crate) fn to_traced(&self) -> TracedPromise {
-        TracedPromise(self.0.clone())
+        TracedPromise(self.duplicate_unrooted())
     }
 }
 
 impl From<&'_ RootedPromise> for TrustedPromise {
     fn from(promise: &'_ RootedPromise) -> Self {
-        TrustedPromise::new(promise.0.clone())
+        TrustedPromise::new(promise.duplicate_unrooted())
     }
 }
 
@@ -115,10 +110,14 @@ impl js::conversions::FromJSValConvertible for RootedPromise {
 
 impl ToJSValConvertible for RootedPromise {
     fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue<'_>) {
-        self.0.to_jsval(cx, rval)
+        self.0.0.to_jsval(cx, rval)
     }
 }
 
+/// A reference to a Promise object. The Promise will not be collected by the GC
+/// as long as the TracedPromise is reachable while tracing the GC heap.
+/// TracedPromise must only be stored inside of structs that are traced during a GC
+/// operation (such as reflected DOM objects), as enforced by the `crown` linter.
 #[derive(Clone, MallocSizeOf, JSTraceable)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TracedPromise(#[conditional_malloc_size_of] Rc<Promise>);
@@ -131,16 +130,17 @@ impl std::cmp::PartialEq for TracedPromise {
 
 impl HeapTracedPromiseHelpers<crate::DomTypeHolder> for TracedPromise {
     type StackRoot = RootedPromise;
-    fn root(&self) -> RootedPromise {
-        TracedPromise::root(self)
+    fn root(&self, cx: &JSContext) -> RootedPromise {
+        TracedPromise::root(self, cx)
     }
 }
 
 impl js::rust::Rootable for TracedPromise {}
 
 impl TracedPromise {
-    pub(crate) fn root(&self) -> RootedPromise {
-        RootedPromise(self.0.clone())
+    /// Obtain a [RootedPromise] for the underlying promise.
+    pub(crate) fn root(&self, cx: &JSContext) -> RootedPromise {
+        self.duplicate(cx)
     }
 }
 
@@ -148,6 +148,47 @@ impl Deref for TracedPromise {
     type Target = Promise;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// A manual GC root that will exist until this PermanentRoot is dropped.
+#[derive(JSTraceable)] // TODO: remove this once this is no longer part of Promise.
+#[derive(Default, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+struct PermanentRoot(#[ignore_malloc_size_of = "mozjs value"] Heap<JSVal>);
+
+impl PermanentRoot {
+    /// Add a GC root for the provided JS object.
+    ///
+    /// SAFETY: This method must only be called on a PermanentRoot that will not
+    /// move for the remainder of its lifetime (e.g. inside of Box, Rc, etc.)
+    #[expect(unsafe_code)]
+    unsafe fn init(&self, cx: &JSContext, object: HandleObject) {
+        self.0.set(ObjectValue(*object));
+        unsafe {
+            assert!(AddRawValueRoot(
+                cx,
+                self.0.get_unsafe(),
+                c"Promise::root".as_ptr(),
+            ));
+        }
+    }
+}
+
+impl Drop for PermanentRoot {
+    #[expect(unsafe_code)]
+    fn drop(&mut self) {
+        let js_root = self.0.get();
+        if js_root.is_undefined() {
+            return;
+        }
+        let object = js_root.to_object();
+        assert!(!object.is_null());
+        if let Some(cx) = Runtime::get() {
+            unsafe {
+                RemoveRawValueRoot(cx.as_ptr(), self.0.get_unsafe());
+            }
+        }
     }
 }
 
@@ -159,57 +200,27 @@ pub(crate) struct Promise {
     /// the SpiderMonkey GC, an explicit root for the reflector is stored while any
     /// native instance exists. This ensures that the reflector will never be GCed
     /// while native code could still interact with its native representation.
-    #[ignore_malloc_size_of = "SM handles JS values"]
-    permanent_js_root: Heap<JSVal>,
-}
-
-/// Private helper to enable adding new methods to `Rc<Promise>`.
-trait PromiseHelper {
-    fn initialize(&self, cx: &JSContext);
-}
-
-impl PromiseHelper for Rc<Promise> {
-    #[expect(unsafe_code)]
-    fn initialize(&self, cx: &JSContext) {
-        let obj = self.reflector().get_jsobject();
-        self.permanent_js_root.set(ObjectValue(*obj));
-        unsafe {
-            assert!(AddRawValueRoot(
-                cx,
-                self.permanent_js_root.get_unsafe(),
-                c"Promise::root".as_ptr(),
-            ));
-        }
-    }
-}
-
-// Promise objects are stored inside Rc values, so Drop is run when the last Rc is dropped,
-// rather than when SpiderMonkey runs a GC. This makes it safe to interact with the JS engine unlike
-// Drop implementations for other DOM types.
-impl Drop for Promise {
-    #[expect(unsafe_code)]
-    fn drop(&mut self) {
-        unsafe {
-            let object = self.permanent_js_root.get().to_object();
-            assert!(!object.is_null());
-            if let Some(cx) = Runtime::get() {
-                RemoveRawValueRoot(cx.as_ptr(), self.permanent_js_root.get_unsafe());
-            }
-        }
-    }
+    /// FIXME(#47747) Deprecated and planned for removal.
+    permanent_js_root: Option<PermanentRoot>,
 }
 
 impl Promise {
+    /// Create a new [RootedPromise] associated with the provided global.
     pub(crate) fn new_rooted(cx: &mut JSContext, global: &GlobalScope) -> RootedPromise {
-        RootedPromise(Self::new(cx, global))
+        let mut realm = enter_auto_realm(cx, global);
+        let cx = &mut realm.current_realm();
+        Promise::new_in_realm_rooted(cx)
     }
 
+    /// Create a new [Promise] associated with the provided global.
+    /// Deprecated. Use [Promise::new_rooted] instead.
     pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> Rc<Promise> {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         Promise::new_in_realm(cx)
     }
 
+    /// Create a new [Promise] associated with the provided realm.
     pub(crate) fn new_in_realm(current_realm: &mut CurrentRealm) -> Rc<Promise> {
         let cx = current_realm.deref_mut();
         rooted!(&in(cx) let mut obj = ptr::null_mut::<JSObject>());
@@ -217,34 +228,75 @@ impl Promise {
         Promise::new_with_js_promise(cx, obj.handle())
     }
 
+    /// Create a new [RootedPromise] associated with the provided realm.
+    /// Deprecated. Use [Promise::new_in_realm_rooted] instead.
     pub(crate) fn new_in_realm_rooted(current_realm: &mut CurrentRealm) -> RootedPromise {
-        RootedPromise(Self::new_in_realm(current_realm))
+        let cx = current_realm.deref_mut();
+        rooted!(&in(cx) let mut obj = ptr::null_mut::<JSObject>());
+        Promise::create_js_promise(cx, obj.handle_mut());
+        Promise::new_with_js_promise_rooted(cx, obj.handle())
     }
 
+    /// Create a new [RootedPromise] wrapping the same underlying [Promise].
     pub(crate) fn duplicate(&self, cx: &JSContext) -> RootedPromise {
         Promise::new_with_js_promise_rooted(cx, self.reflector().get_jsobject())
     }
 
     #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn new_with_js_promise(cx: &JSContext, obj: HandleObject) -> Rc<Promise> {
+    fn duplicate_unrooted(&self) -> Rc<Promise> {
+        let promise = Promise {
+            reflector: Reflector::new(),
+            permanent_js_root: None,
+        };
+        let promise = Rc::new(promise);
+        unsafe {
+            promise.init_reflector_without_associated_memory(self.reflector().get_jsobject().get());
+        }
+        promise
+    }
+
+    /// Create a new [Promise] wrapping the provided JS object.
+    /// Panics if the provided object is not a JS promise.
+    /// Deprecated. Use [Promise::new_with_js_promise_rooted] instead.
+    #[expect(unsafe_code)]
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn new_with_js_promise<'a, 'b>(cx: &'a JSContext, obj: HandleObject<'b>) -> Rc<Promise> {
         unsafe {
             assert!(IsPromiseObject(obj));
         }
         let promise = Promise {
             reflector: Reflector::new(),
-            permanent_js_root: Heap::default(),
+            permanent_js_root: Some(PermanentRoot::default()),
         };
         let promise = Rc::new(promise);
         unsafe {
             promise.init_reflector_without_associated_memory(obj.get());
+            promise.permanent_js_root.as_ref().unwrap().init(cx, obj);
         }
-        promise.initialize(cx);
         promise
     }
 
+    /// Create a new [RootedPromise] wrapping the provided JS object.
+    /// Panics if the provided object is not a JS promise.
+    #[expect(unsafe_code)]
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_with_js_promise_rooted(cx: &JSContext, obj: HandleObject) -> RootedPromise {
-        RootedPromise(Self::new_with_js_promise(cx, obj))
+        unsafe {
+            assert!(IsPromiseObject(obj));
+        }
+        let promise = Promise {
+            reflector: Reflector::new(),
+            permanent_js_root: None,
+        };
+        let promise = Rc::new((promise, PermanentRoot::default()));
+        unsafe {
+            promise
+                .0
+                .init_reflector_without_associated_memory(obj.get());
+            promise.1.init(cx, obj);
+        }
+        RootedPromise(promise)
     }
 
     #[expect(unsafe_code)]
@@ -272,49 +324,79 @@ impl Promise {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn new_resolved(
+    fn new_resolved_shared<F, T>(
         cx: &mut JSContext,
         global: &GlobalScope,
         value: impl ToJSValConvertible,
-    ) -> Rc<Promise> {
+        constructor: F,
+    ) -> T
+    where
+        F: for<'a, 'b> Fn(&'a JSContext, HandleObject<'b>) -> T,
+    {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
         value.to_jsval(cx, rval.handle_mut());
         rooted!(&in(cx) let p = unsafe { CallOriginalPromiseResolve(cx, rval.handle()) });
         assert!(!p.handle().is_null());
-        Promise::new_with_js_promise(cx, p.handle())
+        constructor(cx, p.handle())
     }
 
+    /// Create a new [Promise] associated with the provided global, resolved with the provided value.
+    /// Deprecated. Use [Promise::new_resolved_rooted] instead.
+    pub(crate) fn new_resolved(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        value: impl ToJSValConvertible,
+    ) -> Rc<Promise> {
+        Self::new_resolved_shared(cx, global, value, Promise::new_with_js_promise)
+    }
+
+    /// Create a new [RootedPromise] associated with the provided global, resolved with the provided value.
     pub(crate) fn new_resolved_rooted(
         cx: &mut JSContext,
         global: &GlobalScope,
         value: impl ToJSValConvertible,
     ) -> RootedPromise {
-        RootedPromise(Self::new_resolved(cx, global, value))
+        Self::new_resolved_shared(cx, global, value, Promise::new_with_js_promise_rooted)
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn new_rejected(
+    fn new_rejected_shared<F, T>(
         cx: &mut JSContext,
         global: &GlobalScope,
         value: impl ToJSValConvertible,
-    ) -> Rc<Promise> {
+        constructor: F,
+    ) -> T
+    where
+        F: for<'a, 'b> Fn(&'a JSContext, HandleObject<'b>) -> T,
+    {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
         value.to_jsval(cx, rval.handle_mut());
         rooted!(&in(cx) let p = unsafe { CallOriginalPromiseReject(cx, rval.handle()) });
         assert!(!p.handle().is_null());
-        Promise::new_with_js_promise(cx, p.handle())
+        constructor(cx, p.handle())
     }
 
+    /// Create a new [Promise] associated with the provided global, rejected with the provided value.
+    /// Deprecated. Use [Promise::new_rejected_rooted] instead.
+    pub(crate) fn new_rejected(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        value: impl ToJSValConvertible,
+    ) -> Rc<Promise> {
+        Self::new_rejected_shared(cx, global, value, Promise::new_with_js_promise)
+    }
+
+    /// Create a new [RootedPromise] associated with the provided global, rejected with the provided value.
     pub(crate) fn new_rejected_rooted(
         cx: &mut JSContext,
         global: &GlobalScope,
         value: impl ToJSValConvertible,
     ) -> RootedPromise {
-        RootedPromise(Self::new_rejected(cx, global, value))
+        Self::new_rejected_shared(cx, global, value, Promise::new_with_js_promise_rooted)
     }
 
     pub(crate) fn resolve_native<T>(&self, cx: &mut JSContext, val: &T)

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -53,7 +53,7 @@ use crate::realms::enter_auto_realm;
 use crate::runtime::job_queue::MicrotaskRunnable;
 
 /// A reference to a Promise object, treated as a GC root. The Promise will not
-/// be collected by the GC before this RootedPromise is dropped..
+/// be collected by the GC before this RootedPromise is dropped.
 /// RootedPromise must never be stored inside of structs that are traced during a GC
 /// operation (such as reflected DOM objects) because it can lead to permanent
 /// GC cycles that prevent memory from being reclaimed.
@@ -155,13 +155,21 @@ impl Deref for TracedPromise {
 #[derive(JSTraceable)] // TODO: remove this once this is no longer part of Promise.
 #[derive(Default, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+/// Maintains a GC root for the contained value until this object is dropped.
+///
+/// # Safety
+/// The root (and the contained value) is only valid as long as this value
+/// is never moved after it is initialized. It should only be used inside
+/// of a container like Box or Rc and never extracted from it.
 struct PermanentRoot(#[ignore_malloc_size_of = "mozjs value"] Heap<JSVal>);
 
 impl PermanentRoot {
     /// Add a GC root for the provided JS object.
     ///
-    /// SAFETY: This method must only be called on a PermanentRoot that will not
-    /// move for the remainder of its lifetime (e.g. inside of Box, Rc, etc.)
+    /// # Safety
+    /// - This method must only be called on a `PermanentRoot` that will not
+    ///   move for the remainder of its lifetime (e.g. inside of Box, Rc, etc.)
+    /// - This must only be called once per instance of `PermanentRoot`
     #[expect(unsafe_code)]
     unsafe fn init(&self, cx: &JSContext, object: HandleObject) {
         self.0.set(ObjectValue(*object));
@@ -213,7 +221,8 @@ impl Promise {
     }
 
     /// Create a new [Promise] associated with the provided global.
-    /// Deprecated. Use [Promise::new_rooted] instead.
+    ///
+    /// **Deprecated:** Use [Promise::new_rooted] instead.
     pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> Rc<Promise> {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
@@ -229,7 +238,8 @@ impl Promise {
     }
 
     /// Create a new [RootedPromise] associated with the provided realm.
-    /// Deprecated. Use [Promise::new_in_realm_rooted] instead.
+    ///
+    /// **Deprecated:** Use [Promise::new_in_realm_rooted] instead.
     pub(crate) fn new_in_realm_rooted(current_realm: &mut CurrentRealm) -> RootedPromise {
         let cx = current_realm.deref_mut();
         rooted!(&in(cx) let mut obj = ptr::null_mut::<JSObject>());
@@ -258,10 +268,11 @@ impl Promise {
 
     /// Create a new [Promise] wrapping the provided JS object.
     /// Panics if the provided object is not a JS promise.
-    /// Deprecated. Use [Promise::new_with_js_promise_rooted] instead.
+    ///
+    /// **Deprecated:** Use [Promise::new_with_js_promise_rooted] instead.
     #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn new_with_js_promise<'a, 'b>(cx: &'a JSContext, obj: HandleObject<'b>) -> Rc<Promise> {
+    pub(crate) fn new_with_js_promise(cx: &JSContext, obj: HandleObject) -> Rc<Promise> {
         unsafe {
             assert!(IsPromiseObject(obj));
         }
@@ -342,8 +353,10 @@ impl Promise {
         constructor(cx, p.handle())
     }
 
-    /// Create a new [Promise] associated with the provided global, resolved with the provided value.
-    /// Deprecated. Use [Promise::new_resolved_rooted] instead.
+    /// Create a new [Promise] associated with the provided global,
+    /// resolved with the provided value.
+    ///
+    /// **Deprecated:** Use [Promise::new_resolved_rooted] instead.
     pub(crate) fn new_resolved(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -352,7 +365,8 @@ impl Promise {
         Self::new_resolved_shared(cx, global, value, Promise::new_with_js_promise)
     }
 
-    /// Create a new [RootedPromise] associated with the provided global, resolved with the provided value.
+    /// Create a new [RootedPromise] associated with the provided global,
+    /// resolved with the provided value.
     pub(crate) fn new_resolved_rooted(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -380,8 +394,10 @@ impl Promise {
         constructor(cx, p.handle())
     }
 
-    /// Create a new [Promise] associated with the provided global, rejected with the provided value.
-    /// Deprecated. Use [Promise::new_rejected_rooted] instead.
+    /// Create a new [Promise] associated with the provided global,
+    /// rejected with the provided value.
+    ///
+    /// **Deprecated:** Use [Promise::new_rejected_rooted] instead.
     pub(crate) fn new_rejected(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -390,7 +406,8 @@ impl Promise {
         Self::new_rejected_shared(cx, global, value, Promise::new_with_js_promise)
     }
 
-    /// Create a new [RootedPromise] associated with the provided global, rejected with the provided value.
+    /// Create a new [RootedPromise] associated with the provided global,
+    /// rejected with the provided value.
     pub(crate) fn new_rejected_rooted(
         cx: &mut JSContext,
         global: &GlobalScope,

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -139,7 +139,7 @@ impl ByteTeeUnderlyingSource {
                         &self.branch_2.get().expect("Branch 2 should be set."),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        &self.cancel_promise.root(),
+                        &self.cancel_promise.root(cx),
                         self.reader_version.clone(),
                         expected_version,
                     );
@@ -156,7 +156,7 @@ impl ByteTeeUnderlyingSource {
                         &self.branch_2.get().expect("Branch 2 should be set."),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        &self.cancel_promise.root(),
+                        &self.cancel_promise.root(cx),
                         self.reader_version.clone(),
                         expected_version,
                     );
@@ -207,7 +207,7 @@ impl ByteTeeUnderlyingSource {
                         self.reading.clone(),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        &self.cancel_promise.root(),
+                        &self.cancel_promise.root(cx),
                         self,
                         global,
                     );
@@ -277,7 +277,7 @@ impl ByteTeeUnderlyingSource {
                         self.reading.clone(),
                         self.canceled_1.clone(),
                         self.canceled_2.clone(),
-                        &self.cancel_promise.root(),
+                        &self.cancel_promise.root(cx),
                         self,
                         global,
                     );
@@ -453,7 +453,7 @@ impl ByteTeeUnderlyingSource {
                 }
 
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.root()))
+                Some(Ok(self.cancel_promise.root(cx)))
             },
             ByteTeeCancelAlgorithm::Cancel2Algorithm => {
                 // Set canceled_2 to true.
@@ -467,7 +467,7 @@ impl ByteTeeUnderlyingSource {
                     self.resolve_cancel_promise(cx);
                 }
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.root()))
+                Some(Ok(self.cancel_promise.root(cx)))
             },
         }
     }

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -125,7 +125,7 @@ impl DefaultTeeUnderlyingSource {
             self.canceled_1.clone(),
             self.canceled_2.clone(),
             self.clone_for_branch_2.clone(),
-            &self.cancel_promise.root(),
+            &self.cancel_promise.root(cx),
             self,
         );
 
@@ -164,7 +164,7 @@ impl DefaultTeeUnderlyingSource {
                     self.resolve_cancel_promise(cx, global);
                 }
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.root()))
+                Some(Ok(self.cancel_promise.root(cx)))
             },
             DefaultTeeCancelAlgorithm::Cancel2Algorithm => {
                 // Set canceled_2 to true.
@@ -178,7 +178,7 @@ impl DefaultTeeUnderlyingSource {
                     self.resolve_cancel_promise(cx, global);
                 }
                 // Return cancelPromise.
-                Some(Ok(self.cancel_promise.root()))
+                Some(Ok(self.cancel_promise.root(cx)))
             },
         }
     }

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -373,7 +373,7 @@ impl PipeTo {
             *state = PipeToState::PendingReady;
         }
 
-        let ready_promise = self.writer.Ready();
+        let ready_promise = self.writer.Ready(cx);
         if ready_promise.is_fulfilled() {
             self.read_chunk(cx, global);
         } else {
@@ -388,7 +388,7 @@ impl PipeTo {
             // Note: if the writer is not ready,
             // in order to ensure progress we must
             // also react to the closure of the source(because source may close empty).
-            let closed_promise = self.reader.Closed();
+            let closed_promise = self.reader.Closed(cx);
             closed_promise.append_native_handler(cx, &handler);
         }
     }
@@ -407,7 +407,7 @@ impl PipeTo {
 
         // Note: in order to ensure progress we must
         // also react to the closure of the destination.
-        let ready_promise = self.writer.Closed();
+        let ready_promise = self.writer.Closed(cx);
         ready_promise.append_native_handler(cx, &handler);
     }
 

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -521,8 +521,8 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>
-    fn Closed(&self) -> RootedPromise {
-        self.closed()
+    fn Closed(&self, cx: &JSContext) -> RootedPromise {
+        self.closed(cx)
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
@@ -532,8 +532,8 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
 }
 
 impl ReadableStreamGenericReader for ReadableStreamBYOBReader {
-    fn get_closed_promise(&self) -> RootedPromise {
-        self.closed_promise.borrow().root()
+    fn get_closed_promise(&self, cx: &JSContext) -> RootedPromise {
+        self.closed_promise.borrow().root(cx)
     }
 
     fn set_closed_promise(&self, promise: &RootedPromise) {

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -683,8 +683,8 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>
-    fn Closed(&self) -> RootedPromise {
-        self.closed()
+    fn Closed(&self, cx: &JSContext) -> RootedPromise {
+        self.closed(cx)
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
@@ -694,8 +694,8 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
 }
 
 impl ReadableStreamGenericReader for ReadableStreamDefaultReader {
-    fn get_closed_promise(&self) -> RootedPromise {
-        self.closed_promise.borrow().root()
+    fn get_closed_promise(&self, cx: &JSContext) -> RootedPromise {
+        self.closed_promise.borrow().root(cx)
     }
 
     fn set_closed_promise(&self, promise: &RootedPromise) {

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -57,7 +57,7 @@ pub(crate) trait ReadableStreamGenericReader {
             self.set_closed_promise(&Promise::new_rejected_rooted(cx, global, error.handle()));
 
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
-            self.get_closed_promise().set_promise_is_handled(cx);
+            self.get_closed_promise(cx).set_promise_is_handled(cx);
         }
     }
 
@@ -96,7 +96,7 @@ pub(crate) trait ReadableStreamGenericReader {
 
             if stream.is_readable() {
                 // If stream.[[state]] is "readable", reject reader.[[closedPromise]] with a TypeError exception.
-                self.get_closed_promise()
+                self.get_closed_promise(cx)
                     .reject_error(cx, Error::Type(c"stream state is not readable".to_owned()));
             } else {
                 // Otherwise, set reader.[[closedPromise]] to a promise rejected with a TypeError exception.
@@ -114,7 +114,7 @@ pub(crate) trait ReadableStreamGenericReader {
                 ));
             }
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.
-            self.get_closed_promise().set_promise_is_handled(cx);
+            self.get_closed_promise(cx).set_promise_is_handled(cx);
 
             // Perform ! stream.[[controller]].[[ReleaseSteps]]().
             stream
@@ -130,8 +130,8 @@ pub(crate) trait ReadableStreamGenericReader {
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>
-    fn closed(&self) -> RootedPromise {
-        self.get_closed_promise()
+    fn closed(&self, cx: &JSContext) -> RootedPromise {
+        self.get_closed_promise(cx)
     }
 
     // <https://streams.spec.whatwg.org/#generic-reader-cancel>
@@ -159,7 +159,7 @@ pub(crate) trait ReadableStreamGenericReader {
 
     fn set_closed_promise(&self, promise: &RootedPromise);
 
-    fn get_closed_promise(&self) -> RootedPromise;
+    fn get_closed_promise(&self, cx: &JSContext) -> RootedPromise;
 
     fn as_default_reader(&self) -> Option<&ReadableStreamDefaultReader> {
         None

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -176,7 +176,7 @@ impl Callback for CancelPromiseFulfillment {
             rooted!(&in(cx) let mut error = UndefinedValue());
             self.readable.get_stored_error(error.handle_mut());
             self.controller
-                .get_finish_promise()
+                .get_finish_promise(cx)
                 .expect("finish promise is not set")
                 .reject_native(cx, &error.handle());
         } else {
@@ -190,7 +190,7 @@ impl Callback for CancelPromiseFulfillment {
 
             // Resolve controller.[[finishPromise]] with undefined.
             self.controller
-                .get_finish_promise()
+                .get_finish_promise(cx)
                 .expect("finish promise is not set")
                 .resolve_native(cx, &());
         }
@@ -216,7 +216,7 @@ impl Callback for CancelPromiseRejection {
 
         // Reject controller.[[finishPromise]] with r.
         self.controller
-            .get_finish_promise()
+            .get_finish_promise(cx)
             .expect("finish promise is not set")
             .reject(cx, v);
     }
@@ -242,7 +242,7 @@ impl Callback for SourceCancelPromiseFulfillment {
         // If cancelPromise was fulfilled, then:
         let finish_promise = self
             .controller
-            .get_finish_promise()
+            .get_finish_promise(cx)
             .expect("finish promise is not set");
 
         let global = &self.writeable.global();
@@ -296,7 +296,7 @@ impl Callback for SourceCancelPromiseRejection {
 
         // Reject controller.[[finishPromise]] with r.
         self.controller
-            .get_finish_promise()
+            .get_finish_promise(cx)
             .expect("finish promise is not set")
             .reject(cx, v);
     }
@@ -319,7 +319,7 @@ impl Callback for FlushPromiseFulfillment {
         // If flushPromise was fulfilled, then:
         let finish_promise = self
             .controller
-            .get_finish_promise()
+            .get_finish_promise(cx)
             .expect("finish promise is not set");
 
         // If readable.[[state]] is "errored", reject controller.[[finishPromise]] with readable.[[storedError]].
@@ -358,7 +358,7 @@ impl Callback for FlushPromiseRejection {
 
         // Reject controller.[[finishPromise]] with r.
         self.controller
-            .get_finish_promise()
+            .get_finish_promise(cx)
             .expect("finish promise is not set")
             .reject(cx, v);
     }
@@ -716,7 +716,7 @@ impl TransformStream {
         let controller = self.controller.get().expect("controller is not set");
 
         // If controller.[[finishPromise]] is not undefined, return controller.[[finishPromise]].
-        if let Some(finish_promise) = controller.get_finish_promise() {
+        if let Some(finish_promise) = controller.get_finish_promise(cx) {
             return Ok(finish_promise);
         }
 
@@ -752,7 +752,7 @@ impl TransformStream {
 
         // Return controller.[[finishPromise]].
         let finish_promise = controller
-            .get_finish_promise()
+            .get_finish_promise(cx)
             .expect("finish promise is not set");
         Ok(finish_promise)
     }
@@ -770,7 +770,7 @@ impl TransformStream {
             .ok_or(Error::Type(c"controller is not set".to_owned()))?;
 
         // If controller.[[finishPromise]] is not undefined, return controller.[[finishPromise]].
-        if let Some(finish_promise) = controller.get_finish_promise() {
+        if let Some(finish_promise) = controller.get_finish_promise(cx) {
             return Ok(finish_promise);
         }
 
@@ -803,12 +803,15 @@ impl TransformStream {
             })),
         );
 
-        let mut realm = enter_auto_realm(cx, global);
-        let realm = &mut realm.current_realm();
-        flush_promise.append_native_handler(realm, &handler);
+        {
+            let mut realm = enter_auto_realm(cx, global);
+            let realm = &mut realm.current_realm();
+            flush_promise.append_native_handler(realm, &handler);
+        }
+
         // Return controller.[[finishPromise]].
         let finish_promise = controller
-            .get_finish_promise()
+            .get_finish_promise(cx)
             .expect("finish promise is not set");
         Ok(finish_promise)
     }
@@ -827,7 +830,7 @@ impl TransformStream {
             .ok_or(Error::Type(c"controller is not set".to_owned()))?;
 
         // If controller.[[finishPromise]] is not undefined, return controller.[[finishPromise]].
-        if let Some(finish_promise) = controller.get_finish_promise() {
+        if let Some(finish_promise) = controller.get_finish_promise(cx) {
             return Ok(finish_promise);
         }
 
@@ -863,13 +866,14 @@ impl TransformStream {
             })),
         );
 
-        // Return controller.[[finishPromise]].
-        let finish_promise = controller
-            .get_finish_promise()
-            .expect("finish promise is not set");
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         cancel_promise.append_native_handler(cx, &handler);
+
+        // Return controller.[[finishPromise]].
+        let finish_promise = controller
+            .get_finish_promise(cx)
+            .expect("finish promise is not set");
         Ok(finish_promise)
     }
 
@@ -894,7 +898,7 @@ impl TransformStream {
             .borrow()
             .as_ref()
             .expect("Promise must be some by now.")
-            .root())
+            .root(cx))
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-error-writable-and-unblock-write>

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -170,11 +170,11 @@ impl TransformStreamDefaultController {
         self.stream.set(Some(stream));
     }
 
-    pub(crate) fn get_finish_promise(&self) -> Option<RootedPromise> {
+    pub(crate) fn get_finish_promise(&self, cx: &JSContext) -> Option<RootedPromise> {
         self.finish_promise
             .borrow()
             .as_ref()
-            .map(|promise| promise.root())
+            .map(|promise| promise.root(cx))
     }
 
     pub(crate) fn set_finish_promise(&self, promise: &RootedPromise) {

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -315,7 +315,7 @@ impl UnderlyingSourceContainer {
             },
             UnderlyingSource::Transform(_, start_promise) => {
                 // Let startAlgorithm be an algorithm that returns startPromise.
-                Some(Ok(start_promise.root()))
+                Some(Ok(start_promise.root(cx)))
             },
             _ => None,
         }

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -680,7 +680,7 @@ impl WritableStream {
                 .as_ref()
                 .expect("Pending abort request must be Some.")
                 .promise
-                .root();
+                .root(cx);
         }
 
         // Assert: state is "writable" or "erroring".

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -563,7 +563,7 @@ impl WritableStreamDefaultController {
             },
             UnderlyingSinkType::Transform(_, start_promise) => {
                 // Let startAlgorithm be an algorithm that returns startPromise.
-                Ok(start_promise.root())
+                Ok(start_promise.root(cx))
             },
         }
     }

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -425,9 +425,9 @@ impl WritableStreamDefaultWriter {
 
 impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStreamDefaultWriter {
     /// <https://streams.spec.whatwg.org/#default-writer-closed>
-    fn Closed(&self) -> RootedPromise {
+    fn Closed(&self, cx: &JSContext) -> RootedPromise {
         // Return this.[[closedPromise]].
-        return self.closed_promise.borrow().root();
+        return self.closed_promise.borrow().root(cx);
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-desired-size>
@@ -442,9 +442,9 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-ready>
-    fn Ready(&self) -> RootedPromise {
+    fn Ready(&self, cx: &JSContext) -> RootedPromise {
         // Return this.[[readyPromise]].
-        return self.ready_promise.borrow().root();
+        return self.ready_promise.borrow().root(cx);
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-abort>

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -431,7 +431,7 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
-    fn Lost(&self, cx: &mut JSContext) -> RootedPromise {
+    fn Lost(&self, cx: &JSContext) -> RootedPromise {
         self.lost_promise.borrow().root(cx)
     }
 

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -431,8 +431,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
-    fn Lost(&self) -> RootedPromise {
-        self.lost_promise.borrow().root()
+    fn Lost(&self, cx: &mut JSContext) -> RootedPromise {
+        self.lost_promise.borrow().root(cx)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -594,8 +594,8 @@ DOMInterfaces = {
         'CreateTexture', 'CreateSampler', 'CreateRenderPipeline',  'CreateRenderBundleEncoder',
         'CreateQuerySet',
         'ImportExternalTexture',
-        'Lost',
     ],
+    'cx_no_gc': ['Lost'],
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
     'no_gc': ['SetLabel'],
 },
@@ -639,7 +639,7 @@ DOMInterfaces = {
 
 'GPUShaderModule': {
     'no_gc': ['SetLabel'],
-    'cx': ['GetCompilationInfo'],
+    'cx_no_gc': ['GetCompilationInfo'],
 },
 
 'GPUTexture': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -501,6 +501,7 @@ DOMInterfaces = {
 
 'FontFace': {
     'cx': ['Load'],
+    'cx_no_gc': ['Loaded'],
 },
 
 'FontFaceSet': {
@@ -593,6 +594,7 @@ DOMInterfaces = {
         'CreateTexture', 'CreateSampler', 'CreateRenderPipeline',  'CreateRenderBundleEncoder',
         'CreateQuerySet',
         'ImportExternalTexture',
+        'Lost',
     ],
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
     'no_gc': ['SetLabel'],
@@ -637,6 +639,7 @@ DOMInterfaces = {
 
 'GPUShaderModule': {
     'no_gc': ['SetLabel'],
+    'cx': ['GetCompilationInfo'],
 },
 
 'GPUTexture': {
@@ -1047,7 +1050,6 @@ DOMInterfaces = {
 'Promise': {
     'spiderMonkeyInterface': True,
     'additionalTraits': ["js::conversions::FromJSValConvertibleRc", "crate::interfaces::PromiseHelpers<Self>"],
-    'allowDropImpl': True,
 },
 
 'RadioNodeList': {
@@ -1622,10 +1624,12 @@ DOMInterfaces = {
 
 "ReadableStreamBYOBReader": {
     "cx": ["Cancel", "Read", "ReleaseLock"],
+    "cx_no_gc": ["Closed"],
 },
 
 "ReadableStreamDefaultReader": {
     "cx": ["Cancel", "Read", "ReleaseLock"],
+    "cx_no_gc": ["Closed"],
 },
 
 'ResizeObserver': {
@@ -1666,6 +1670,7 @@ DOMInterfaces = {
 
 'WritableStreamDefaultWriter': {
     'cx': ['ReleaseLock'],
+    'cx_no_gc': ['Closed', 'Ready'],
     'realm': ['Abort', 'Close', 'Constructor', 'Write'],
 },
 

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -95,7 +95,7 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
 
 pub trait HeapTracedPromiseHelpers<D: DomTypes> {
     type StackRoot;
-    fn root(&self) -> Self::StackRoot;
+    fn root(&self, cx: &JSContext) -> Self::StackRoot;
 }
 
 pub trait StackRootPromiseHelpers<D: DomTypes> {

--- a/components/script_webgpu/gpushadermodule.rs
+++ b/components/script_webgpu/gpushadermodule.rs
@@ -154,7 +154,7 @@ impl<D: DomTypes> GPUShaderModuleMethods<D> for GPUShaderModule<D> {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>
     fn GetCompilationInfo(
         &self,
-        cx: &mut JSContext,
+        cx: &JSContext,
     ) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
         self.compilation_info_promise.root(cx)
     }

--- a/components/script_webgpu/gpushadermodule.rs
+++ b/components/script_webgpu/gpushadermodule.rs
@@ -152,10 +152,7 @@ impl<D: DomTypes> GPUShaderModuleMethods<D> for GPUShaderModule<D> {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>
-    fn GetCompilationInfo(
-        &self,
-        cx: &JSContext,
-    ) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
+    fn GetCompilationInfo(&self, cx: &JSContext) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
         self.compilation_info_promise.root(cx)
     }
 }

--- a/components/script_webgpu/gpushadermodule.rs
+++ b/components/script_webgpu/gpushadermodule.rs
@@ -152,7 +152,10 @@ impl<D: DomTypes> GPUShaderModuleMethods<D> for GPUShaderModule<D> {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>
-    fn GetCompilationInfo(&self) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
-        self.compilation_info_promise.root()
+    fn GetCompilationInfo(
+        &self,
+        cx: &mut JSContext,
+    ) -> <D::Promise as PromiseHelpers<D>>::StackRoot {
+        self.compilation_info_promise.root(cx)
     }
 }


### PR DESCRIPTION
This change introduces actual behaviour differences between `Rc<Promise>`, `RootedPromise`, and `TracedPromise`. `Rc<Promise>`. Any `Rc<Promise>` returned from constructor methods on `Promise` is rooted. `RootedPromise` values are always rooted. `TracedPromise` values are never rooted. More subtly, `Rc<Promise>` values _extracted_ from either `RootedPromise` or `TracedPromise` are never rooted, so #47954 is required to avoid introducing a soundness hole.

Once #47747 is fixed we will be able to remove all Promise methods that return new `Rc<Promise>` objects, as well as the ability for a `Promise` instance to root itself. 

Testing: Existing tests suffice. I saw lots of crashes in WPT when I didn't get the rooting logic quite right while iterating on this code.
Fixes: #47749
Part of #45262
Depends upon #47954