### PR TITLE
script_bindings: Add `DomRoot::as_unrooted` and `Dom::as_unrooted`

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -649,7 +649,7 @@ impl Element {
             .as_ref()?
             .shadow_root
             .as_ref()
-            .map(|shadow_root| UnrootedDom::from_dom(shadow_root.clone(), no_gc))
+            .map(|shadow_root| shadow_root.as_unrooted(no_gc))
     }
 
     pub(crate) fn is_shadow_host(&self) -> bool {

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -21,7 +21,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLAnchorElementBinding::HTMLAncho
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::NodeTypeId;
-use crate::dom::bindings::root::{Dom, DomRoot, DomSlice, UnrootedDom};
+use crate::dom::bindings::root::{DomRoot, DomSlice, UnrootedDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::element::Element;
@@ -43,7 +43,7 @@ pub(crate) enum NodeOrString<'a> {
 
 impl<'a> NodeOrString<'a> {
     pub(crate) fn from_node(node: &Node, no_gc: &'a NoGC) -> NodeOrString<'a> {
-        NodeOrString::Node(UnrootedDom::from_dom(Dom::from_ref(node), no_gc))
+        NodeOrString::Node(UnrootedDom::from_ref(node, no_gc))
     }
 
     fn as_node(&self) -> Option<UnrootedDom<'a, Node>> {
@@ -1622,7 +1622,7 @@ impl Node {
         let Some(editing_host) = self.editing_host_of() else {
             return false;
         };
-        let self_unrooted = UnrootedDom::from_dom(Dom::from_ref(self), no_gc);
+        let self_unrooted = UnrootedDom::from_ref(self, no_gc);
         self.ancestors_unrooted(no_gc)
             .take_while(|ancestor| ancestor.editing_host_of().as_ref() == Some(&editing_host))
             .all(|ancestor| {

--- a/components/script/dom/html/embedded_content/htmltrackelement.rs
+++ b/components/script/dom/html/embedded_content/htmltrackelement.rs
@@ -184,7 +184,7 @@ impl HTMLTrackElement {
     }
 
     pub(crate) fn track<'a>(&self, no_gc: &'a NoGC) -> UnrootedDom<'a, TextTrack> {
-        UnrootedDom::from_dom(self.track.clone(), no_gc)
+        self.track.as_unrooted(no_gc)
     }
 }
 

--- a/components/script/dom/html/form_controls/htmlformelement.rs
+++ b/components/script/dom/html/form_controls/htmlformelement.rs
@@ -200,7 +200,7 @@ impl HTMLFormElement {
             .iter()
             .filter(|n| HTMLFormElement::filter_for_radio_list(mode, n, name))
             .nth(index as usize)
-            .map(|n| UnrootedDom::upcast(UnrootedDom::from_dom(n.clone(), no_gc)))
+            .map(|node| UnrootedDom::upcast(node.as_unrooted(no_gc)))
     }
 
     pub(crate) fn count_for_radio_list(&self, mode: RadioListMode, name: &Atom) -> u32 {

--- a/components/script/dom/node/iterators.rs
+++ b/components/script/dom/node/iterators.rs
@@ -9,7 +9,7 @@ use crate::dom::Node;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRoot_Binding::ShadowRootMethods;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::root::{Dom, DomRoot, UnrootedDom};
+use crate::dom::bindings::root::{DomRoot, UnrootedDom};
 use crate::dom::element::Element;
 use crate::dom::shadowroot::ShadowRoot;
 
@@ -418,7 +418,7 @@ pub(crate) struct UnrootedTreeIterator<'b> {
 impl<'b> UnrootedTreeIterator<'b> {
     pub(crate) fn new(root: &Node, shadow_including: ShadowIncluding, no_gc: &'b NoGC) -> Self {
         Self {
-            current: Some(UnrootedDom::from_dom(Dom::from_ref(root), no_gc)),
+            current: Some(UnrootedDom::from_ref(root, no_gc)),
             depth: 0,
             shadow_including,
             no_gc,
@@ -523,7 +523,7 @@ pub(crate) struct UnrootedFollowingFlatTreeNodesTraversal<'no_gc> {
 impl<'no_gc> UnrootedFollowingFlatTreeNodesTraversal<'no_gc> {
     pub(crate) fn new(root: &Node, no_gc: &'no_gc NoGC) -> Self {
         Self {
-            start: UnrootedDom::from_dom(Dom::from_ref(root), no_gc),
+            start: UnrootedDom::from_ref(root, no_gc),
             previously_returned_item: None,
             no_gc,
         }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -935,7 +935,7 @@ impl Node {
         no_gc: &'b NoGC,
     ) -> impl Iterator<Item = UnrootedDom<'b, Node>> + use<'b> {
         UnrootedSimpleNodeIterator::new(
-            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            Some(UnrootedDom::from_ref(self, no_gc)),
             |n, no_gc| n.get_next_sibling_unrooted(no_gc),
             no_gc,
         )
@@ -946,7 +946,7 @@ impl Node {
         no_gc: &'b NoGC,
     ) -> impl Iterator<Item = UnrootedDom<'b, Node>> + use<'b> {
         UnrootedSimpleNodeIterator::new(
-            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            Some(UnrootedDom::from_ref(self, no_gc)),
             |n, no_gc| n.get_previous_sibling_unrooted(no_gc),
             no_gc,
         )
@@ -1054,8 +1054,8 @@ impl Node {
         shadow_including: ShadowIncluding,
     ) -> UnrootedFollowingNodeIterator<'b> {
         UnrootedFollowingNodeIterator::new(
-            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
-            UnrootedDom::from_dom(Dom::from_ref(root), no_gc),
+            Some(UnrootedDom::from_ref(self, no_gc)),
+            UnrootedDom::from_ref(root, no_gc),
             shadow_including,
             no_gc,
         )
@@ -1071,8 +1071,8 @@ impl Node {
         root: &Node,
     ) -> UnrootedPrecedingNodeIterator<'b> {
         UnrootedPrecedingNodeIterator::new(
-            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
-            UnrootedDom::from_dom(Dom::from_ref(root), no_gc),
+            Some(UnrootedDom::from_ref(self, no_gc)),
+            UnrootedDom::from_ref(root, no_gc),
             no_gc,
         )
     }
@@ -1652,9 +1652,9 @@ impl Node {
             .id_map()
             .resolve_all(cx.no_gc(), self.owner_doc().upcast());
 
-        let traced_node = UnrootedDom::from_dom(Dom::from_ref(self), cx.no_gc());
+        let unrooted_node = UnrootedDom::from_ref(self, cx.no_gc());
         let matching_elements = with_layout_state(|| {
-            let layout_node: LayoutDom<'_, _> = unsafe { traced_node.to_layout() };
+            let layout_node: LayoutDom<'_, _> = unsafe { unrooted_node.to_layout() };
             ServoDangerousStyleNode::from(layout_node)
                 .scope_match_a_selectors_string::<QueryAll>(document_url, &selectors.str())
         })?;
@@ -1704,17 +1704,14 @@ impl Node {
         shadow_including: ShadowIncluding,
     ) -> impl Iterator<Item = UnrootedDom<'a, Node>> + use<'a> {
         UnrootedSimpleNodeIterator::new(
-            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
-            move |n, no_gc| {
+            Some(UnrootedDom::from_ref(self, no_gc)),
+            move |node, no_gc| {
                 if shadow_including == ShadowIncluding::Yes &&
-                    let Some(shadow_root) = n.downcast::<ShadowRoot>()
+                    let Some(shadow_root) = node.downcast::<ShadowRoot>()
                 {
-                    return Some(UnrootedDom::from_dom(
-                        Dom::from_ref(shadow_root.host_unrooted(no_gc).upcast::<Node>()),
-                        no_gc,
-                    ));
+                    return Some(UnrootedDom::upcast(shadow_root.host_unrooted(no_gc)));
                 }
-                n.get_parent_node_unrooted(no_gc)
+                node.get_parent_node_unrooted(no_gc)
             },
             no_gc,
         )
@@ -1750,7 +1747,7 @@ impl Node {
             .as_ref()?
             .containing_shadow_root
             .as_ref()
-            .map(|shadow_root| UnrootedDom::from_dom(shadow_root.clone(), no_gc))
+            .map(|shadow_root| shadow_root.as_unrooted(no_gc))
     }
 
     pub(crate) fn set_containing_shadow_root(&self, shadow_root: Option<&ShadowRoot>) {
@@ -2098,7 +2095,7 @@ impl Node {
     ) -> Option<UnrootedDom<'a, HTMLSlotElement>> {
         let rare_data = self.rare_data.borrow();
         let assigned_slot = rare_data.as_ref()?.slottable_data.assigned_slot.as_ref()?;
-        Some(UnrootedDom::from_dom(Dom::from_ref(assigned_slot), no_gc))
+        Some(UnrootedDom::from_ref(assigned_slot, no_gc))
     }
 
     pub(crate) fn set_assigned_slot(&self, assigned_slot: Option<&HTMLSlotElement>) {
@@ -2146,10 +2143,7 @@ impl Node {
         };
 
         if let Some(shadow_root) = parent.downcast::<ShadowRoot>() {
-            return FlatTreeParent::Parent(UnrootedDom::from_dom(
-                Dom::from_ref(shadow_root.Host().upcast::<Node>()),
-                no_gc,
-            ));
+            return FlatTreeParent::Parent(UnrootedDom::upcast(shadow_root.host_unrooted(no_gc)));
         }
 
         if parent
@@ -2174,12 +2168,9 @@ impl Node {
         no_gc: &'a NoGC,
     ) -> impl Iterator<Item = UnrootedDom<'a, Node>> + use<'a> {
         UnrootedSimpleNodeIterator::new(
-            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            Some(UnrootedDom::from_ref(self, no_gc)),
             move |node, no_gc| match node.parent_in_flat_tree(no_gc) {
-                FlatTreeParent::Parent(parent) => {
-                    // Supoptimal
-                    Some(UnrootedDom::from_dom(Dom::from_ref(&*parent), no_gc))
-                },
+                FlatTreeParent::Parent(parent) => Some(parent),
                 FlatTreeParent::NotInFlatTree | FlatTreeParent::RootNode => None,
             },
             no_gc,
@@ -3509,7 +3500,7 @@ impl Node {
                 .skip_while(|slottable| &*slottable.0 != self)
                 // Skip `self` so that this moves on the the next node in the list of slottables.
                 .nth(1)
-                .map(|next_slottable| UnrootedDom::from_dom(next_slottable.0.clone(), no_gc));
+                .map(|next_slottable| next_slottable.0.as_unrooted(no_gc));
         }
         self.get_next_sibling_unrooted(no_gc)
     }
@@ -3548,7 +3539,7 @@ impl Node {
             slot_element.has_assigned_nodes() &&
             let Some(assigned_node) = slot_element.assigned_nodes().first()
         {
-            return Some(UnrootedDom::from_dom(assigned_node.0.clone(), no_gc));
+            return Some(assigned_node.0.as_unrooted(no_gc));
         }
 
         self.get_first_child_unrooted(no_gc)

--- a/components/script/dom/node/nodelist.rs
+++ b/components/script/dom/node/nodelist.rs
@@ -157,7 +157,7 @@ impl NodeList {
         match self.list_type {
             NodeListType::Simple(ref elems) => elems
                 .get(index as usize)
-                .map(|node| UnrootedDom::from_dom(node.clone(), no_gc)),
+                .map(|node| node.as_unrooted(no_gc)),
             NodeListType::Children(ref list) => list.item(no_gc, index),
             NodeListType::Labels(ref list) => list.item(no_gc, index),
             NodeListType::Radio(ref list) => list.item(no_gc, index),
@@ -205,7 +205,7 @@ impl ChildrenList {
                     .collect()
             })
             .get(index as usize)
-            .map(|child| UnrootedDom::from_dom(child.clone(), no_gc))
+            .map(|child| child.as_unrooted(no_gc))
     }
 
     pub(crate) fn children_changed(&self, mutation: &ChildrenMutation) {

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -391,11 +391,11 @@ impl Range {
         }
 
         let document = start.owner_doc();
-        let end_clone = UnrootedDom::from_dom(Dom::from_ref(&*end), no_gc);
+        let unrooted_end = end.as_unrooted(no_gc);
         start
             .following_nodes_unrooted(no_gc, document.upcast::<Node>(), ShadowIncluding::No)
             .take_while(move |node| *node != *end)
-            .chain(iter::once(end_clone))
+            .chain(iter::once(unrooted_end))
             .flat_map(move |node| node.border_boxes())
             .collect()
     }

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -151,7 +151,7 @@ impl TextTrackList {
                     .borrow()
                     .clone()
                     .into_iter()
-                    .map(|track| UnrootedDom::from_dom(track, no_gc)),
+                    .map(|track| track.as_unrooted(no_gc)),
             ),
         }
     }

--- a/components/script_bindings/dom.rs
+++ b/components/script_bindings/dom.rs
@@ -123,7 +123,7 @@ impl<'a, T: DomObject> UnrootedDom<'a, T> {
     /// the token and the token should ensure that no garbage collection will take place
     /// as long as it is alive.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub fn from_dom(object: Dom<T>, _no_gc: &'a NoGC) -> UnrootedDom<'a, T> {
+    pub(crate) fn from_dom(object: Dom<T>, _no_gc: &'a NoGC) -> UnrootedDom<'a, T> {
         UnrootedDom {
             inner: object,
             _phantom: PhantomData,

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::{fmt, mem, ptr};
 
+use js::context::NoGC;
 use js::gc::{Handle, Traceable as JSTraceable};
 use js::jsapi::{Heap, JSObject, JSTracer};
 use js::rust::GCMethods;
@@ -15,6 +16,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::assert::assert_in_script;
 use crate::conversions::DerivedFrom;
+use crate::dom::UnrootedDom;
 use crate::inheritance::Castable;
 use crate::reflector::{DomObject, MutDomObject};
 use crate::trace::trace_reflector;
@@ -186,6 +188,12 @@ impl<T: DomObject> Dom<T> {
         DomRoot::from_ref(self)
     }
 
+    /// Return an unrooted version of this DOM object ([`UnrootedDom<T>`]) suitable for use on the
+    /// stack which has the lifetime of the provided [`NoGC`] token.
+    pub fn as_unrooted<'no_gc>(&self, no_gc: &'no_gc NoGC) -> UnrootedDom<'no_gc, T> {
+        UnrootedDom::from_dom(self.clone(), no_gc)
+    }
+
     pub fn as_ptr(&self) -> *const T {
         self.ptr.as_ptr()
     }
@@ -312,6 +320,12 @@ impl<T: DomObject> DomRoot<T> {
     /// end up as members of other DOM objects.
     pub fn as_traced(&self) -> Dom<T> {
         Dom::from_ref(self)
+    }
+
+    /// Return an unrooted version of this DOM object ([`UnrootedDom<T>`]) suitable for use on the
+    /// stack which has the lifetime of the provided [`NoGC`] token.
+    pub fn as_unrooted<'no_gc>(&self, no_gc: &'no_gc NoGC) -> UnrootedDom<'no_gc, T> {
+        self.value.as_unrooted(no_gc)
     }
 }
 

--- a/components/script_bindings/weakref.rs
+++ b/components/script_bindings/weakref.rs
@@ -22,7 +22,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use crate::JSTraceable;
 use crate::dom::UnrootedDom;
 use crate::reflector::DomObject;
-use crate::root::{Dom, DomRoot};
+use crate::root::DomRoot;
 
 /// A weak reference to a JS-managed DOM object.
 #[derive(Clone)]
@@ -66,7 +66,7 @@ impl<T: WeakReferenceable> WeakRef<T> {
     pub fn unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, T>> {
         self.0
             .upgrade()
-            .map(|x| UnrootedDom::from_dom(Dom::from_ref(&*x), no_gc))
+            .map(|value| UnrootedDom::from_ref(&*value, no_gc))
     }
 
     /// Return whether the weakly-referenced object is still alive.


### PR DESCRIPTION
This change adds two helpers which make it easier to convert these kinds
of value into `UnrootedDom` and starts to use them when possible.
Additionally, call sites creating `UnrootedDom` values are generally
cleaned up.

Testing: This should not change behavior so is covered by existing tests.
