### PR TITLE
servoshell/fonts: Fix clippy warnings in OHOS code

### DIFF
--- a/components/fonts/platform/freetype/ohos/font_cache.rs
+++ b/components/fonts/platform/freetype/ohos/font_cache.rs
@@ -80,7 +80,7 @@ fn remove_redundant_cache_files() {
             if (filename_components.len() == 2) && // the font cache file only has one `_`. So the vector length from splitting must be 2.
                         (filename_components[1] == cache_filename_components[1]) && // check if the suffix is the same
                         (filename_components[0] != cache_filename_components[0])
-                && let Err(e) = fs::remove_file(format!("{}{}", &base_dir, filename))
+                && let Err(e) = fs::remove_file(format!("{}{}", base_dir, filename))
             {
                 error!(
                     "Obsolete font cache file found; but failed to remove it: {:?}",

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -148,7 +148,7 @@ fn set_efficient_window_method(window: *mut c_void) {
             return;
         }
 
-        usage = usage & (!(ohos_window_sys::native_buffer::native_buffer::OH_NativeBuffer_Usage::NATIVEBUFFER_USAGE_CPU_READ.0 as u64));
+        usage &= !(ohos_window_sys::native_buffer::native_buffer::OH_NativeBuffer_Usage::NATIVEBUFFER_USAGE_CPU_READ.0 as u64);
         let return_value = ohos_window_sys::native_window::OH_NativeWindow_NativeWindowHandleOpt(
             window as *mut ohos_sys_opaque_types::NativeWindow,
             ohos_window_sys::native_window::NativeWindowOperation::SET_USAGE as i32,
@@ -1175,9 +1175,8 @@ impl Ime for ServoIme {
     }
 
     fn keyboard_status_changed(&self, status: KeyboardStatus) {
-        match status {
-            KeyboardStatus::Hidden => call(ServoAction::ImeDismiss).unwrap(),
-            _ => (),
+        if let KeyboardStatus::Hidden = status {
+            call(ServoAction::ImeDismiss).unwrap()
         }
     }
 }


### PR DESCRIPTION
ohos normally does not get clippy warnings, so these changes were missed.

Testing: Just clippy warnings, compilation is the test.
