### PR TITLE
script_webgpu: Move GlobalScope and Promise trait bounds to Equivalence trait

### DIFF
--- a/components/script_webgpu/gpu.rs
+++ b/components/script_webgpu/gpu.rs
@@ -56,10 +56,7 @@ impl<D: Equivalence> GPU<D> {
 impl<D> GPUMethods<D> for GPU<D>
 where
     D: Equivalence,
-    D::Promise: PromiseHelpers<D>,
     <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
-    D::GPU: DomGlobalGeneric<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpu-requestadapter>

--- a/components/script_webgpu/gpuadapter.rs
+++ b/components/script_webgpu/gpuadapter.rs
@@ -189,9 +189,7 @@ where
 impl<D> GPUAdapterMethods<D> for GPUAdapter<D>
 where
     D: Equivalence,
-    D::Promise: PromiseHelpers<D>,
     <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice>

--- a/components/script_webgpu/gpubindgroup.rs
+++ b/components/script_webgpu/gpubindgroup.rs
@@ -14,7 +14,6 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUBindGroupDescriptor, GPUBindGroupMethods, GPUBindGroupWrap,
 };
-use script_bindings::interfaces::PromiseHelpers;
 use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{WebGPU, WebGPUBindGroup, WebGPUDevice, WebGPURequest};
 use wgpu_core::binding_model::BindGroupDescriptor;
@@ -103,8 +102,6 @@ where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
     D::GPUExternalTexture: GPUExternalTextureTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
-    D::Promise: PromiseHelpers<D>,
 {
     pub fn id(&self) -> &WebGPUBindGroup {
         &self.droppable.bind_group

--- a/components/script_webgpu/gpubindgrouplayout.rs
+++ b/components/script_webgpu/gpubindgrouplayout.rs
@@ -98,7 +98,6 @@ impl<D> GPUBindGroupLayout<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     pub fn id(&self) -> WebGPUBindGroupLayout {
         self.droppable.bind_group_layout

--- a/components/script_webgpu/gpubuffer.rs
+++ b/components/script_webgpu/gpubuffer.rs
@@ -455,8 +455,7 @@ where
 
 impl<D> GPUBuffer<D>
 where
-    D: DomTypes,
-    D::Promise: PromiseHelpers<D> + PartialEq,
+    D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
 {
     pub fn map_failure(

--- a/components/script_webgpu/gpucommandencoder.rs
+++ b/components/script_webgpu/gpucommandencoder.rs
@@ -102,7 +102,6 @@ impl<D> GPUCommandEncoder<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D> + DomGlobalGeneric<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
 {
     pub(crate) fn id(&self) -> WebGPUCommandEncoder {

--- a/components/script_webgpu/gpucomputepassencoder.rs
+++ b/components/script_webgpu/gpucomputepassencoder.rs
@@ -22,9 +22,7 @@ use crate::gpubindgroup::GPUBindGroup;
 use crate::gpubuffer::GPUBuffer;
 use crate::gpucommandencoder::GPUCommandEncoder;
 use crate::gpucomputepipeline::GPUComputePipeline;
-use crate::traits::{
-    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUGlobalTrait, WebGPUPromiseTrait,
-};
+use crate::traits::{Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUPromiseTrait};
 
 #[derive(MallocSizeOf)]
 struct DroppableGPUComputePassEncoder {
@@ -100,10 +98,8 @@ where
 impl<D> GPUComputePassEncoderMethods<D> for GPUComputePassEncoder<D>
 where
     D: Equivalence,
-    D::GlobalScope: WebGPUGlobalTrait,
     D::GPUDevice: GPUDeviceTrait<D>,
     D::GPUExternalTexture: GPUExternalTextureTrait<D>,
-    D::Promise: PromiseHelpers<D>,
     <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>

--- a/components/script_webgpu/gpucomputepipeline.rs
+++ b/components/script_webgpu/gpucomputepipeline.rs
@@ -11,7 +11,7 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUComputePipelineDescriptor, GPUComputePipelineMethods, GPUComputePipelineWrap,
 };
-use script_bindings::interfaces::{GlobalScopeHelpers, PromiseHelpers};
+use script_bindings::interfaces::PromiseHelpers;
 use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
@@ -103,9 +103,7 @@ where
 impl<D> GPUComputePipeline<D>
 where
     D: Equivalence,
-    D::Promise: PromiseHelpers<D>,
     <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
     D::GPUDevice: GPUDeviceTrait<D>,
 {
     pub(crate) fn id(&self) -> &WebGPUComputePipeline {

--- a/components/script_webgpu/gpuconvert.rs
+++ b/components/script_webgpu/gpuconvert.rs
@@ -21,7 +21,7 @@ use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUTextureViewDimension, GPUVertexFormat,
 };
 use script_bindings::codegen::GenericUnionTypes::GPUTextureOrGPUTextureView;
-use script_bindings::interfaces::{GlobalScopeHelpers, PromiseHelpers};
+use script_bindings::interfaces::PromiseHelpers;
 use script_bindings::reflector::DomGlobalGeneric;
 use webgpu_traits::WebGPUTextureView;
 use wgpu_core::binding_model::{BindGroupEntry, BindingResource, BufferBinding};
@@ -31,9 +31,7 @@ use wgpu_core::resource::{QuerySetDescriptor, TextureDescriptor};
 use wgpu_types::{self, AstcBlock, AstcChannel, IndexFormat};
 
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::traits::{
-    Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUGlobalTrait, WebGPUPromiseTrait,
-};
+use crate::traits::{Equivalence, GPUDeviceTrait, GPUExternalTextureTrait, WebGPUPromiseTrait};
 
 /// A version of the `Into<T>` trait from the standard library that can be used
 /// to convert between two types that are not defined in the script crate.
@@ -521,8 +519,6 @@ impl<D> WebGPUConvert<wgpu_com::TexelCopyBufferInfo> for &GPUTexelCopyBufferInfo
 where
     D: Equivalence,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
-    D::Promise: PromiseHelpers<D>,
 {
     fn convert(self) -> wgpu_com::TexelCopyBufferInfo {
         wgpu_com::TexelCopyBufferInfo {
@@ -587,7 +583,6 @@ impl<D> WebGPUTryConvert<wgpu_com::TexelCopyTextureInfo> for &GPUTexelCopyTextur
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     type Error = Error;
 
@@ -758,9 +753,7 @@ impl WebGPUTryConvert<wgpu_types::Color> for &GPUColor {
 impl<'a, D> WebGPUConvert<ProgrammableStageDescriptor<'a>> for &GPUProgrammableStage<D>
 where
     D: Equivalence,
-    D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::Promise: PromiseHelpers<D>,
     <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
 {
     fn convert(self) -> ProgrammableStageDescriptor<'a> {
@@ -787,7 +780,6 @@ pub fn convert_texture_for_wgpu_with_cx<D>(
 where
     D: Equivalence,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     match texture_view {
         GPUTextureOrGPUTextureView::GPUTextureView(view) => view.id(),
@@ -803,8 +795,6 @@ where
     D: Equivalence,
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
     D::GPUExternalTexture: GPUExternalTextureTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
-    D::Promise: PromiseHelpers<D>,
 {
     BindGroupEntry {
         binding: bind_group.binding,
@@ -871,7 +861,6 @@ impl<D> WebGPUConvert<PassTimestampWrites> for &GPUComputePassTimestampWrites<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     fn convert(self) -> PassTimestampWrites {
         PassTimestampWrites {
@@ -886,7 +875,6 @@ impl<D> WebGPUConvert<PassTimestampWrites> for &GPURenderPassTimestampWrites<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     fn convert(self) -> PassTimestampWrites {
         PassTimestampWrites {
@@ -901,7 +889,6 @@ impl<D> WebGPUConvert<ComputePassDescriptor<'static>> for &GPUComputePassDescrip
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     fn convert(self) -> ComputePassDescriptor<'static> {
         ComputePassDescriptor {

--- a/components/script_webgpu/gpupipelinelayout.rs
+++ b/components/script_webgpu/gpupipelinelayout.rs
@@ -105,7 +105,6 @@ impl<D> GPUPipelineLayout<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     pub fn id(&self) -> WebGPUPipelineLayout {
         self.droppable.pipeline_layout

--- a/components/script_webgpu/gpuqueryset.rs
+++ b/components/script_webgpu/gpuqueryset.rs
@@ -59,7 +59,6 @@ impl<D> GPUQuerySet<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     pub(crate) fn new_inherited(
         label: USVString,
@@ -152,7 +151,6 @@ impl<D> GPUQuerySetMethods<D> for GPUQuerySet<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy>
     fn Destroy(&self) {

--- a/components/script_webgpu/gpurenderbundleencoder.rs
+++ b/components/script_webgpu/gpurenderbundleencoder.rs
@@ -14,7 +14,7 @@ use script_bindings::codegen::GenericBindings::WebGPUBinding::{
     GPUIndexFormat, GPURenderBundleDescriptor, GPURenderBundleEncoderDescriptor,
     GPURenderBundleEncoderMethods, GPURenderBundleEncoderWrap,
 };
-use script_bindings::interfaces::{GlobalScopeHelpers, PromiseHelpers};
+use script_bindings::interfaces::GlobalScopeHelpers;
 use script_bindings::reflector::{DomGlobalGeneric, Reflector, reflect_dom_object_with_wrap};
 use webgpu_traits::{
     RenderBundleCommand, WebGPU, WebGPURenderBundle, WebGPURenderBundleEncoder, WebGPURequest,
@@ -108,7 +108,6 @@ impl<D> GPURenderBundleEncoder<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderbundleencoder>
@@ -188,7 +187,6 @@ where
     D::GPUDevice: DomGlobalGeneric<D> + GPUDeviceTrait<D>,
     D::GPUExternalTexture: GPUExternalTextureTrait<D>,
     D::GlobalScope: WebGPUGlobalTrait + GlobalScopeHelpers<D>,
-    D::Promise: PromiseHelpers<D>,
     Self: DomGlobalGeneric<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>

--- a/components/script_webgpu/gpurenderpassencoder.rs
+++ b/components/script_webgpu/gpurenderpassencoder.rs
@@ -60,7 +60,6 @@ impl<D> GPURenderPassEncoder<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     fn new_inherited(
         channel: WebGPU,

--- a/components/script_webgpu/gpurenderpipeline.rs
+++ b/components/script_webgpu/gpurenderpipeline.rs
@@ -102,7 +102,6 @@ impl<D> GPURenderPipeline<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
 {
     pub(crate) fn id(&self) -> WebGPURenderPipeline {
@@ -138,7 +137,6 @@ where
 impl<D> GPURenderPipelineMethods<D> for GPURenderPipeline<D>
 where
     D: Equivalence,
-    D::GlobalScope: DomGlobalGeneric<D> + WebGPUGlobalTrait,
     D::GPUDevice: GPUDeviceTrait<D>,
     Self: DomGlobalGeneric<D>,
 {

--- a/components/script_webgpu/gpusampler.rs
+++ b/components/script_webgpu/gpusampler.rs
@@ -100,7 +100,6 @@ impl<D: Equivalence> GPUSampler<D> {
 impl<D> GPUSampler<D>
 where
     D: Equivalence,
-    D::GlobalScope: WebGPUGlobalTrait,
     D::GPUDevice: GPUDeviceTrait<D>,
 {
     pub(crate) fn id(&self) -> WebGPUSampler {

--- a/components/script_webgpu/gpushadermodule.rs
+++ b/components/script_webgpu/gpushadermodule.rs
@@ -98,9 +98,7 @@ impl<D: Equivalence> GPUShaderModule<D> {
 impl<D> GPUShaderModule<D>
 where
     D: Equivalence,
-    D::Promise: PromiseHelpers<D>,
     <D::Promise as PromiseHelpers<D>>::StackRoot: WebGPUPromiseTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
     D::GPUDevice: GPUDeviceTrait<D>,
 {
     pub(crate) fn id(&self) -> WebGPUShaderModule {

--- a/components/script_webgpu/gputexture.rs
+++ b/components/script_webgpu/gputexture.rs
@@ -135,7 +135,6 @@ impl<D> GPUTexture<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
 {
     pub fn id(&self) -> WebGPUTexture {
         self.droppable.texture
@@ -209,7 +208,6 @@ impl<D> GPUTextureMethods<D> for GPUTexture<D>
 where
     D: Equivalence,
     D::GPUDevice: GPUDeviceTrait<D>,
-    D::GlobalScope: WebGPUGlobalTrait,
     Self: DomGlobalGeneric<D>,
 {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>

--- a/components/script_webgpu/traits.rs
+++ b/components/script_webgpu/traits.rs
@@ -8,6 +8,7 @@ use script_bindings::DomTypes;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUTextureFormat;
 use script_bindings::codegen::GenericUnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use script_bindings::error::Fallible;
+use script_bindings::interfaces::PromiseHelpers;
 use script_bindings::reflector::DomGlobalGeneric;
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
@@ -96,7 +97,9 @@ pub trait Equivalence =  DomTypes<
         GPUTextureView = GPUTextureView<Self>,
         GPUUncapturedErrorEvent = GPUUncapturedErrorEvent<Self>,
         GPUValidationError = GPUValidationError<Self>,
-        WGSLLanguageFeatures = WGSLLanguageFeatures<Self>>;
+        WGSLLanguageFeatures = WGSLLanguageFeatures<Self>,
+        Promise: PromiseHelpers<Self> + PartialEq,
+        GlobalScope: WebGPUGlobalTrait>;
 }
 
 /// The main trait for creating and using promises in script_webgpu.


### PR DESCRIPTION
To clean up the code, we can move some of the requirements to the Equivalence traits. We keep temporary traits around because they will vanish soon. Trait bounds on Self are kept for clarity and bounds on StackRoot miight not be supported by the macro yet.

Testing: This just changes where the trait bounds are given, so compilation is the test.
