### PR TITLE
layout: Complement of preferred-aspect-ratio on 4 non-replaced boxes

### DIFF
--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use geom::{FlexAxis, MainStartCrossStart};
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
@@ -23,8 +24,10 @@ use crate::dom::{LayoutBox, WeakLayoutBox};
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
+use crate::geom::LogicalVec2;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::AbsolutelyPositionedBox;
+use crate::style_ext::{AspectRatio, ComputedValuesExt};
 
 mod geom;
 mod layout;
@@ -149,6 +152,14 @@ impl FlexContainer {
     pub(crate) fn repair_style(&mut self, new_style: &ServoArc<ComputedValues>) {
         self.config = FlexContainerConfig::new(new_style);
         self.style = new_style.clone();
+    }
+
+    #[inline]
+    pub(crate) fn preferred_aspect_ratio(
+        &self,
+        padding_border_sums: &LogicalVec2<Au>,
+    ) -> Option<AspectRatio> {
+        self.style.preferred_aspect_ratio(None, padding_border_sums)
     }
 
     pub(crate) fn subtree_size(&self) -> usize {

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -41,7 +41,9 @@ use crate::sizing::{
     self, ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize, Size,
     SizeConstraint, Sizes,
 };
-use crate::style_ext::{AspectRatio, ContentBoxSizesAndPBM, LayoutStyle, PaddingBorderMargin};
+use crate::style_ext::{
+    AspectRatio, ComputedValuesExt, ContentBoxSizesAndPBM, LayoutStyle, PaddingBorderMargin,
+};
 use crate::{ConstraintSpace, ContainingBlock, ContainingBlockSize, IndefiniteContainingBlock};
 
 mod construct;
@@ -73,6 +75,17 @@ impl BlockContainer {
                 .any(|block_level_box| block_level_box.borrow().contains_floats()),
             BlockContainer::InlineFormattingContext(context) => context.contains_floats,
         }
+    }
+
+    #[inline]
+    pub(crate) fn preferred_aspect_ratio(
+        &self,
+        base: &LayoutBoxBase,
+        padding_border_sums: &LogicalVec2<Au>,
+    ) -> Option<AspectRatio> {
+        self.layout_style(base)
+            .style()
+            .preferred_aspect_ratio(None, padding_border_sums)
     }
 
     pub(crate) fn repair_style(
@@ -516,6 +529,15 @@ impl BlockFormattingContext {
     #[inline]
     pub(crate) fn layout_style<'a>(&self, base: &'a LayoutBoxBase) -> LayoutStyle<'a> {
         LayoutStyle::Default(&base.style)
+    }
+
+    #[inline]
+    pub(crate) fn preferred_aspect_ratio(
+        &self,
+        base: &LayoutBoxBase,
+        padding_border_sums: &LogicalVec2<Au>,
+    ) -> Option<AspectRatio> {
+        self.contents.preferred_aspect_ratio(base, padding_border_sums)
     }
 
     pub(crate) fn repair_style(

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -341,7 +341,26 @@ impl IndependentFormattingContext {
                     };
                 Some((block_size.into(), depends_on_inline_stretch_size))
             },
-            _ => None,
+            IndependentFormattingContextContents::Flow(_) => {
+                let ratio = preferred_aspect_ratio?;
+                let block_size = ratio.compute_dependent_size(Direction::Block, inline_stretch_size);
+                Some((block_size.into(), true))
+            },
+            IndependentFormattingContextContents::Flex(_) => {
+                let ratio = preferred_aspect_ratio?;
+                let block_size = ratio.compute_dependent_size(Direction::Block, inline_stretch_size);
+                Some((block_size.into(), true))
+            },
+            IndependentFormattingContextContents::Grid(_) => {
+                let ratio = preferred_aspect_ratio?;
+                let block_size = ratio.compute_dependent_size(Direction::Block, inline_stretch_size);
+                Some((block_size.into(), true))
+            },
+            IndependentFormattingContextContents::Table(_) => {
+                let ratio = preferred_aspect_ratio?;
+                let block_size = ratio.compute_dependent_size(Direction::Block, inline_stretch_size);
+                Some((block_size.into(), true))
+            },
         }
     }
 
@@ -577,8 +596,18 @@ impl IndependentFormattingContext {
             IndependentFormattingContextContents::Replaced(replaced, _) => {
                 replaced.preferred_aspect_ratio(self.style(), padding_border_sums)
             },
-            // TODO: support preferred aspect ratios on non-replaced boxes.
-            _ => None,
+            IndependentFormattingContextContents::Flow(contents) => {
+                contents.preferred_aspect_ratio(&self.base, padding_border_sums)
+            },
+            IndependentFormattingContextContents::Flex(contents) => {
+                contents.preferred_aspect_ratio(padding_border_sums)
+            },
+            IndependentFormattingContextContents::Grid(contents) => {
+                contents.preferred_aspect_ratio(padding_border_sums)
+            },
+            IndependentFormattingContextContents::Table(contents) => {
+                contents.preferred_aspect_ratio(padding_border_sums)
+            },
         }
     }
 

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -91,9 +91,9 @@ use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
 };
 use crate::fragment_tree::BaseFragmentInfo;
-use crate::geom::PhysicalVec;
+use crate::geom::{LogicalVec2, PhysicalVec};
 use crate::layout_box_base::LayoutBoxBase;
-use crate::style_ext::BorderStyleColor;
+use crate::style_ext::{AspectRatio, BorderStyleColor, ComputedValuesExt};
 use crate::table::layout::TableLayout;
 use crate::{PropagatedBoxTreeData, SharedStyle};
 
@@ -218,6 +218,14 @@ impl Table {
             .flat_map(|row| row.iter())
             .map(TableSlot::subtree_size)
             .sum()
+    }
+
+    #[inline]
+    pub(crate) fn preferred_aspect_ratio(
+        &self,
+        padding_border_sums: &LogicalVec2<Au>,
+    ) -> Option<AspectRatio> {
+        self.style.preferred_aspect_ratio(None, padding_border_sums)
     }
 }
 

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -5,6 +5,7 @@ mod layout;
 mod stylo_taffy;
 use std::fmt;
 
+use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc;
@@ -21,8 +22,10 @@ use crate::dom::{LayoutBox, WeakLayoutBox};
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::Fragment;
+use crate::geom::LogicalVec2;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
+use crate::style_ext::{AspectRatio, ComputedValuesExt};
 
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct TaffyContainer {
@@ -77,6 +80,14 @@ impl TaffyContainer {
 
     pub(crate) fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.style = new_style.clone();
+    }
+
+    #[inline]
+    pub(crate) fn preferred_aspect_ratio(
+        &self,
+        padding_border_sums: &LogicalVec2<Au>,
+    ) -> Option<AspectRatio> {
+        self.style.preferred_aspect_ratio(None, padding_border_sums)
     }
 }
 


### PR DESCRIPTION
Query and usage of preferred_aspect_ratio() on non-replaced boxes (Flow, Flex, Grid, Table).
New failures in stable unexpected results for WPT tests were passing false positively on the main branch: aspect-ratio does not work for non-replaced boxes at all; the engine does not transfer weights and heights of the items according to the ratio, but just return the minimum value in the css styles, which happens to match the reference value of the tests.
@yezhizhen 