### PR TITLE
mach: Support running unit-tests on ohos

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,3 +8,9 @@ fail-fast = false
 
 [profile.ci.junit]
 path = "junit.xml"
+
+# The default is to use the amount of cores on the host,
+# which is not a good fit for mobile ohos devices.
+[[profile.default.overrides]]
+platform = 'cfg(target_env = "ohos")'
+test-threads = 4

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -541,21 +541,25 @@ mod test {
     #[test]
     fn test_get_system_font_families() {
         use super::get_system_font_families;
-        let families = get_system_font_families(vec![PathBuf::from("NotoSansCJK-Regular.ttc")]);
+        let fonts_dir = PathBuf::from(super::OHOS_FONTS_DIR);
+        let families = get_system_font_families(vec![fonts_dir.join("NotoSansCJK-Regular.ttc")]);
         assert_eq!(families.len(), 1);
         let family = families.first().unwrap();
         assert_eq!(family.name, "Noto Sans CJK".to_string());
 
-        let families = get_system_font_families(vec![
-            PathBuf::from("NotoSerifGeorgian[wdth,wght].ttf"),
-            PathBuf::from("HarmonyOS_Sans_Naskh_Arabic_UI.ttf"),
-            PathBuf::from("HarmonyOS_Sans_Condensed.ttf"),
-            PathBuf::from("HarmonyOS_Sans_Condensed_Italic.ttf"),
-            PathBuf::from("NotoSansDevanagariUI-Bold.ttf"),
-            PathBuf::from("NotoSansDevanagariUI-Medium.ttf"),
-            PathBuf::from("NotoSansDevanagariUI-Regular.ttf"),
-            PathBuf::from("NotoSansDevanagariUI-SemiBold.ttf"),
-        ]);
+        let families_paths = [
+            "NotoSerifGeorgian[wdth,wght].ttf",
+            "HarmonyOS_Sans_Naskh_Arabic_UI.ttf",
+            "HarmonyOS_Sans_Condensed.ttf",
+            "HarmonyOS_Sans_Condensed_Italic.ttf",
+            "NotoSansDevanagariUI-Bold.ttf",
+            "NotoSansDevanagariUI-Medium.ttf",
+            "NotoSansDevanagariUI-Regular.ttf",
+            "NotoSansDevanagariUI-SemiBold.ttf",
+        ]
+        .map(|filename| fonts_dir.join(filename))
+        .to_vec();
+        let families = get_system_font_families(families_paths);
         assert_eq!(families.len(), 4);
     }
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -763,6 +763,7 @@ class CommandBase(object):
         use_crown: bool = False,
         capture_output: bool = False,
         target_override: Optional[str] = None,
+        subcommand: str | None = None,
         **_kwargs: Any,
     ) -> CompletedProcess[bytes] | int:
         env = cast(dict[str, str], env or self.build_env())
@@ -834,10 +835,14 @@ class CommandBase(object):
         # but uv venv on Windows only provides a `python`, not `python3`.
         env["PYTHON3"] = "python"
 
-        if capture_output:
-            return subprocess.run(["cargo", command] + args + cargo_args, env=env, capture_output=capture_output)
+        command_args = [command]
+        if subcommand:
+            command_args.append(subcommand)
 
-        return call(["cargo", command] + args + cargo_args, env=env, verbose=verbose)
+        if capture_output:
+            return subprocess.run(["cargo"] + command_args + args + cargo_args, env=env, capture_output=capture_output)
+
+        return call(["cargo"] + command_args + args + cargo_args, env=env, verbose=verbose)
 
     def android_adb_path(self, env: dict[str, Any]) -> str:
         if "ANDROID_SDK_ROOT" in env:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -265,6 +265,7 @@ class MachCommands(CommandBase):
 
         crown_cargo_command: List[str] = ["cargo"]
         cargo_command: str
+        cargo_subcommand: str | None = None
         if bench:
             cargo_command = "bench"
             if code_coverage:
@@ -284,19 +285,20 @@ class MachCommands(CommandBase):
             crown_cargo_command.extend(["llvm-cov", "nextest"])
             crown_cargo_command.extend(cargo_llvm_cov_options)
             cargo_command = "llvm-cov"
-            args.insert(0, "nextest")
+            cargo_subcommand = "nextest"
             args.extend(cargo_llvm_cov_options)
         elif use_nextest:
             crown_cargo_command.extend(["nextest", "run"])
             cargo_command = "nextest"
-            args.insert(0, "run")
+            cargo_subcommand = "run"
         else:
             crown_cargo_command.extend(["test"])
             cargo_command = "test"
-        result = call(crown_cargo_command, cwd="support/crown")
-        if result != 0:
-            return result
-        result = self.run_cargo_build_like_command(cargo_command, args, env=env, **kwargs)
+        if not self.target.is_cross_build():
+            result = call(crown_cargo_command, cwd="support/crown")
+            if result != 0:
+                return result
+        result = self.run_cargo_build_like_command(cargo_command, args, subcommand=cargo_subcommand, env=env, **kwargs)
         assert isinstance(result, int)
         return result
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -226,6 +226,12 @@ class MachCommands(CommandBase):
             packages = set(os.listdir(path.join(self.context.topdir, "tests", "unit"))) - set([".DS_Store"])
             packages |= set(self_contained_tests)
 
+        # Servoshell is meant as an app library and links in NAPI, which
+        # is not available when running unit-tests.
+        if is_openharmony(self.target) and "servoshell" in packages:
+            print("Skipping servoshell unit tests on OpenHarmony.")
+            packages.remove("servoshell")
+
         in_crate_packages = []
         for crate in self_contained_tests:
             try:

--- a/tests/unit/style/properties/scaffolding.rs
+++ b/tests/unit/style/properties/scaffolding.rs
@@ -8,7 +8,10 @@ use std::path::Path;
 
 use serde_json::{self, Value};
 
+// Skip this test when cross-running tests, since we won't have the file on the target device
+// and the test itself should be target independant.
 #[test]
+#[cfg_attr(any(target_os = "android", target_env = "ohos"), ignore)]
 fn properties_list_json() {
     // Four dotdots: /path/to/target(4)/debug(3)/build(2)/style_tests-*(1)/out
     // Do not ascend above the target dir, because it may not be called target


### PR DESCRIPTION
- Skip crown unit-tests when cross-compiling
- Skip servoshell unit-tests for ohos, since servoshell pulls in NAPI symbols, which are not available when running as an executable instead of an app.
- Add concept of subcommand to the cargo-build-like command, since all parameters should be added after the subcomand (in this case `run` from `cargo nextest run). Maybe an alternative could be to have command be `[str]` instead, but then we'd need to update all callers and there are places which string compare against `command`.

Note that `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_RUNNER` needs to be set to a runner that handles the running of the binaries on the target (ohos-test-runner).

Testing: Currently not covered by automated tests for ohos, but existing supported platforms are executed in CI, so regressions should be caught for those platforms. 
