### PR TITLE
script: Share audio buffer with media backend instead of cloning.

### DIFF
--- a/components/media/audio/buffer_source_node.rs
+++ b/components/media/audio/buffer_source_node.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 
 use crate::audio_node::{
@@ -15,7 +17,7 @@ use crate::param::{Param, ParamType};
 #[derive(Debug, Clone, MallocSizeOf)]
 pub enum AudioBufferSourceNodeMessage {
     /// Set the data block holding the audio sample data to be played.
-    SetBuffer(Option<AudioBuffer>),
+    SetBuffer(#[conditional_malloc_size_of] Option<Arc<AudioBuffer>>),
     /// Set loop parameter.
     SetLoopEnabled(bool),
     /// Set loop parameter.
@@ -63,7 +65,7 @@ impl Default for AudioBufferSourceNodeOptions {
 pub(crate) struct AudioBufferSourceNode {
     channel_info: ChannelInfo,
     /// A data block holding the audio sample data to be played.
-    buffer: Option<AudioBuffer>,
+    buffer: Option<Arc<AudioBuffer>>,
     /// How many more buffer-frames to output. See buffer_pos for clarification.
     buffer_duration: f64,
     /// "Index" of the next buffer frame to play. "Index" is in quotes because
@@ -107,7 +109,7 @@ impl AudioBufferSourceNode {
     pub fn new(options: AudioBufferSourceNodeOptions, channel_info: ChannelInfo) -> Self {
         Self {
             channel_info,
-            buffer: options.buffer,
+            buffer: options.buffer.map(Arc::new),
             buffer_pos: 0.,
             detune: Param::new_krate(options.detune),
             initialized_pos: false,

--- a/components/media/examples/examples/play_noise.rs
+++ b/components/media/examples/examples/play_noise.rs
@@ -40,7 +40,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     context.message_node(
         buffer_source,
         AudioNodeMessage::AudioBufferSourceNode(AudioBufferSourceNodeMessage::SetBuffer(Some(
-            AudioBuffer::from_buffers(buffers, 44100.),
+            AudioBuffer::from_buffers(buffers, 44100.).into(),
         ))),
     );
     let callback = OnEndedCallback::new(|| {

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -3,12 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cmp::min;
+use std::sync::Arc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32, Float32Array, HeapFloat32Array};
-use script_bindings::cell::{DomRefCell, Ref};
+use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use script_bindings::trace::RootedTraceableBox;
 use servo_media::audio::buffer_source_node::AudioBuffer as ServoMediaAudioBuffer;
@@ -46,7 +47,7 @@ pub(crate) struct AudioBuffer {
     /// Aggregates the data from js_channels.
     /// This is `Some<T>` iff the buffers in js_channels are detached.
     #[no_trace]
-    shared_channels: DomRefCell<Option<ServoMediaAudioBuffer>>,
+    shared_channels: DomRefCell<Option<Arc<ServoMediaAudioBuffer>>>,
     /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-samplerate>
     sample_rate: f32,
     /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-length>
@@ -127,7 +128,7 @@ impl AudioBuffer {
                 None => vec![0.; self.length as usize],
             };
         }
-        *self.shared_channels.borrow_mut() = Some(channels);
+        *self.shared_channels.borrow_mut() = Some(Arc::new(channels));
     }
 
     fn restore_js_channel_data(&self, cx: &mut JSContext) -> bool {
@@ -175,17 +176,14 @@ impl AudioBuffer {
         Some(result)
     }
 
-    pub(crate) fn get_channels(
-        &self,
-        cx: &mut JSContext,
-    ) -> Ref<'_, Option<ServoMediaAudioBuffer>> {
+    pub(crate) fn get_channels(&self, cx: &mut JSContext) -> Option<Arc<ServoMediaAudioBuffer>> {
         if self.shared_channels.borrow().is_none() {
-            let channels = self.acquire_contents(cx);
+            let channels = self.acquire_contents(cx).map(Arc::new);
             if channels.is_some() {
                 *self.shared_channels.safe_borrow_mut(cx.no_gc()) = channels;
             }
         }
-        self.shared_channels.borrow()
+        self.shared_channels.borrow().clone()
     }
 }
 

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -47,6 +47,7 @@ pub(crate) struct AudioBuffer {
     /// Aggregates the data from js_channels.
     /// This is `Some<T>` iff the buffers in js_channels are detached.
     #[no_trace]
+    #[conditional_malloc_size_of]
     shared_channels: DomRefCell<Option<Arc<ServoMediaAudioBuffer>>>,
     /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-samplerate>
     sample_rate: f32,

--- a/components/script/dom/audio/audiobuffersourcenode.rs
+++ b/components/script/dom/audio/audiobuffersourcenode.rs
@@ -169,7 +169,7 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
                 self.source_node
                     .node()
                     .message(AudioNodeMessage::AudioBufferSourceNode(
-                        AudioBufferSourceNodeMessage::SetBuffer((*buffer).clone()),
+                        AudioBufferSourceNodeMessage::SetBuffer(buffer),
                     ));
             }
         }
@@ -259,7 +259,7 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
                 self.source_node
                     .node()
                     .message(AudioNodeMessage::AudioBufferSourceNode(
-                        AudioBufferSourceNodeMessage::SetBuffer((*buffer).clone()),
+                        AudioBufferSourceNodeMessage::SetBuffer(buffer),
                     ));
             }
         }
@@ -286,7 +286,7 @@ impl ConvertWithCx<AudioBufferSourceNodeOptions> for AudioBufferSourceOptions {
             buffer: self
                 .buffer
                 .as_ref()
-                .and_then(|b| (*b.as_ref()?.get_channels(cx)).clone()),
+                .and_then(|b| b.as_ref()?.get_channels(cx).map(|buffer| (*buffer).clone())),
             detune: *self.detune,
             loop_enabled: self.loop_,
             loop_end: Some(*self.loopEnd),


### PR DESCRIPTION
This change reduces memory usage of https://ptweb.me/play/GUzd by 50%. It's still absurdly high (10gb), but it's less absurd now.

Testing: Existing tests suffice.
Part of #47960.
