### PR TITLE
malloc_size_of: Measure Arc/Rc from the allocation base

### DIFF
--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -53,5 +53,8 @@ webrender = { workspace = true }
 webrender_api = { workspace = true }
 wr_malloc_size_of = { workspace = true }
 
+[dev-dependencies]
+servo-allocator = { workspace = true }
+
 [lints]
 workspace = true

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -668,9 +668,16 @@ impl<T: MallocSizeOf> MallocConditionalSizeOf for servo_arc::Arc<T> {
     }
 }
 
+/// Recover the allocation base: `Arc::as_ptr`/`Rc::as_ptr` point at the data
+/// after the two reference counts in the `#[repr(C)]` heap allocation.
+fn refcounted_allocation_base<T>(data: *const T) -> *const T {
+    let data_offset = std::mem::align_of::<T>().max(std::mem::size_of::<usize>() * 2);
+    data.wrapping_byte_sub(data_offset)
+}
+
 impl<T> MallocUnconditionalShallowSizeOf for Arc<T> {
     fn unconditional_shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        unsafe { ops.malloc_size_of(Arc::as_ptr(self)) }
+        unsafe { ops.malloc_size_of(refcounted_allocation_base(Arc::as_ptr(self))) }
     }
 }
 
@@ -702,7 +709,7 @@ impl<T: MallocSizeOf> MallocConditionalSizeOf for Arc<T> {
 
 impl<T> MallocUnconditionalShallowSizeOf for Rc<T> {
     fn unconditional_shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        unsafe { ops.malloc_size_of(Rc::as_ptr(self)) }
+        unsafe { ops.malloc_size_of(refcounted_allocation_base(Rc::as_ptr(self))) }
     }
 }
 

--- a/components/malloc_size_of/tests/refcounted_shallow.rs
+++ b/components/malloc_size_of/tests/refcounted_shallow.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use servo_malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
+
+// Large enough to ensure rounding up occurs.
+const PAYLOAD: usize = 100;
+// The allocation also contains two reference counts.
+const MINIMUM: usize = size_of::<usize>() * 2 + PAYLOAD;
+// Leave enough slack for allocator rounding without crossing a page.
+const SLACK: usize = 4096;
+
+fn ops() -> MallocSizeOfOps {
+    MallocSizeOfOps::new(
+        servo_allocator::usable_size,
+        servo_allocator::enclosing_size,
+        None,
+    )
+}
+
+#[test]
+fn arc_shallow_size_is_the_allocation_size() {
+    let arc = Arc::new([0u8; PAYLOAD]);
+    let shallow = arc.unconditional_shallow_size_of(&mut ops());
+    assert!(
+        (MINIMUM..MINIMUM + SLACK).contains(&shallow),
+        "expected roughly {MINIMUM} bytes for the ArcInner allocation, got {shallow}"
+    );
+}
+
+#[test]
+fn rc_shallow_size_is_the_allocation_size() {
+    let rc = Rc::new([0u8; PAYLOAD]);
+    let shallow = rc.unconditional_shallow_size_of(&mut ops());
+    assert!(
+        (MINIMUM..MINIMUM + SLACK).contains(&shallow),
+        "expected roughly {MINIMUM} bytes for the RcInner allocation, got {shallow}"
+    );
+}
+
+#[test]
+fn arc_shallow_size_honors_alignment() {
+    // Alignment greater than two words increases the data offset:
+    // the counts are padded to 64 bytes, so this ZST's allocation is 64 bytes.
+    #[repr(align(64))]
+    struct Aligned;
+
+    let arc = Arc::new(Aligned);
+    let shallow = arc.unconditional_shallow_size_of(&mut ops());
+    let minimum = align_of::<Aligned>();
+    assert!(
+        (minimum..minimum + SLACK).contains(&shallow),
+        "expected roughly {minimum} bytes for the aligned ArcInner allocation, got {shallow}"
+    );
+}


### PR DESCRIPTION
This computes the allocation base from the data pointer when measuring an `Arc` or `Rc` allocation: `as_ptr()` returns a pointer to the data, which lives after the two reference counts in the heap allocation, so passing that interior pointer to `malloc_usable_size` is undefined behavior.

Previously, in debug builds, requesting a memory report could cause the measuring threads to panic due to an integer overflow. In release builds, the report contained garbage values instead.

Testing: three new tests measure `Arc`, `Rc`, and an over-aligned `Arc`; all three fail without this change.