### PR TITLE
net: Replace IPC with generic channels in file/blob management

### DIFF
--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -15,7 +15,6 @@ use embedder_traits::{
     SelectedFile,
 };
 use headers::{ContentLength, ContentRange, ContentType, HeaderMap, HeaderMapExt, Range};
-use ipc_channel::ipc::IpcSender;
 use log::warn;
 use mime::Mime;
 use net_traits::blob_url_store::{BlobBuf, BlobTokenCommunicator, BlobURLStoreError};
@@ -25,6 +24,7 @@ use net_traits::filemanager_thread::{
 };
 use net_traits::response::{Response, ResponseBody};
 use parking_lot::{Mutex, RwLock};
+use profile_traits::generic_callback::GenericCallback;
 use rustc_hash::{FxHashMap, FxHashSet};
 use servo_arc::Arc as ServoArc;
 use servo_base::generic_channel::GenericSender;
@@ -100,7 +100,7 @@ impl FileManager {
 
     fn read_file(
         &self,
-        sender: IpcSender<FileManagerResult<ReadFileProgress>>,
+        sender: GenericCallback<FileManagerResult<ReadFileProgress>>,
         id: Uuid,
         origin: ImmutableOrigin,
     ) {
@@ -661,7 +661,7 @@ impl FileManagerStore {
 
     async fn get_blob_buf(
         &self,
-        sender: &IpcSender<FileManagerResult<ReadFileProgress>>,
+        sender: &GenericCallback<FileManagerResult<ReadFileProgress>>,
         id: &Uuid,
         file_token: &FileTokenCheck,
         origin_in: &ImmutableOrigin,
@@ -737,7 +737,7 @@ impl FileManagerStore {
     // Convenient wrapper over get_blob_buf
     async fn try_read_file(
         &self,
-        sender: &IpcSender<FileManagerResult<ReadFileProgress>>,
+        sender: &GenericCallback<FileManagerResult<ReadFileProgress>>,
         id: Uuid,
         origin_in: ImmutableOrigin,
     ) -> Result<(), BlobURLStoreError> {
@@ -868,7 +868,7 @@ impl FileManagerStore {
 }
 
 async fn read_file_in_chunks(
-    sender: &IpcSender<FileManagerResult<ReadFileProgress>>,
+    sender: &GenericCallback<FileManagerResult<ReadFileProgress>>,
     mut file: tokio::fs::File,
     size: usize,
     opt_filename: Option<String>,

--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, FilePickerRequest, FilterPattern,
 };
-use ipc_channel::ipc;
 use net::async_runtime::init_async_runtime;
 use net::embedder::NetToEmbedderMsg;
 use net::filemanager_thread::FileManager;
@@ -17,6 +16,7 @@ use net_traits::blob_url_store::{BlobTokenCommunicator, BlobURLStoreError};
 use net_traits::filemanager_thread::{
     FileManagerThreadError, FileManagerThreadMsg, ReadFileProgress,
 };
+use profile_traits::generic_callback::GenericCallback;
 use servo_base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
 use servo_base::{Epoch, generic_channel};
 use servo_config::prefs::Preferences;
@@ -101,7 +101,8 @@ fn test_filemanager() {
 
         // Test by reading, expecting same content
         {
-            let (tx2, rx2) = ipc::channel().unwrap();
+            let (tx2, rx2) =
+                GenericCallback::new_blocking(profile_traits::time::ProfilerChan(None)).unwrap();
             filemanager.handle(FileManagerThreadMsg::ReadFile(
                 tx2,
                 selected.id.clone(),
@@ -153,7 +154,8 @@ fn test_filemanager() {
 
         // Test by reading again, expecting read error because we invalidated the id
         {
-            let (tx2, rx2) = ipc::channel().unwrap();
+            let (tx2, rx2) =
+                GenericCallback::new_blocking(profile_traits::time::ProfilerChan(None)).unwrap();
             filemanager.handle(FileManagerThreadMsg::ReadFile(
                 tx2,
                 selected.id.clone(),

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -25,7 +25,6 @@ use embedder_traits::{
 };
 use fonts::FontContext;
 use indexmap::IndexSet;
-use ipc_channel::router::ROUTER;
 use js::context::{JSContext, NoGC};
 use js::jsapi::{GetNonCCWObjectGlobal, HandleObject, Heap, JSObject};
 use js::jsval::UndefinedValue;
@@ -48,8 +47,8 @@ use net_traits::request::{
 };
 use net_traits::{CoreResourceMsg, CoreResourceThread, ReferrerPolicy, ResourceThreads};
 use profile_traits::{
-    generic_channel as profile_generic_channel, ipc as profile_ipc, mem as profile_mem,
-    time as profile_time,
+    generic_callback as profile_generic_callback, generic_channel as profile_generic_channel,
+    mem as profile_mem, time as profile_time,
 };
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::callback::OwnerWindow;
@@ -2168,7 +2167,9 @@ impl GlobalScope {
                     }
 
                     let origin = self.origin().immutable().clone();
-                    let (tx, rx) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
+                    let (tx, rx) =
+                        profile_generic_channel::channel(self.time_profiler_chan().clone())
+                            .unwrap();
 
                     let msg = FileManagerThreadMsg::ActivateBlobURL(f.get_id(), tx, origin);
                     self.send_to_file_manager(msg);
@@ -2204,7 +2205,13 @@ impl GlobalScope {
     }
 
     fn read_file(&self, id: Uuid) -> Result<Vec<u8>, ()> {
-        let recv = self.send_msg(id);
+        let (chan, recv) = profile_generic_callback::GenericCallback::new_blocking(
+            self.time_profiler_chan().clone(),
+        )
+        .expect("Couldn't create read_file callback");
+
+        self.send_msg(id, chan);
+
         GlobalScope::read_msg(recv)
     }
 
@@ -2228,8 +2235,6 @@ impl GlobalScope {
             UnderlyingSourceType::Blob(size),
         )?;
 
-        let recv = self.send_msg(file_id);
-
         let trusted_stream = Trusted::new(&*stream);
         let mut file_listener = FileListener {
             state: Some(FileListenerState::Empty(FileListenerTarget::Stream(
@@ -2238,12 +2243,15 @@ impl GlobalScope {
             task_source: self.task_manager().file_reading_task_source().into(),
         };
 
-        ROUTER.add_typed_route(
-            recv.to_ipc_receiver(),
-            Box::new(move |msg| {
+        let chan = profile_generic_callback::GenericCallback::new(
+            self.time_profiler_chan().clone(),
+            move |msg| {
                 file_listener.handle(msg.expect("Deserialization of file listener msg failed."));
-            }),
-        );
+            },
+        )
+        .expect("Couldn't create get_blob_stream callback");
+
+        self.send_msg(file_id, chan);
 
         Ok(stream)
     }
@@ -2254,8 +2262,6 @@ impl GlobalScope {
         promise: Rc<Promise>,
         callback: FileListenerCallback,
     ) {
-        let recv = self.send_msg(id);
-
         let trusted_promise = TrustedPromise::new(promise);
         let mut file_listener = FileListener {
             state: Some(FileListenerState::Empty(FileListenerTarget::Promise(
@@ -2265,25 +2271,30 @@ impl GlobalScope {
             task_source: self.task_manager().file_reading_task_source().into(),
         };
 
-        ROUTER.add_typed_route(
-            recv.to_ipc_receiver(),
-            Box::new(move |msg| {
+        let chan = profile_generic_callback::GenericCallback::new(
+            self.time_profiler_chan().clone(),
+            move |msg| {
                 file_listener.handle(msg.expect("Deserialization of file listener msg failed."));
-            }),
-        );
+            },
+        )
+        .expect("Couldn't create read_file_async callback");
+
+        self.send_msg(id, chan);
     }
 
-    fn send_msg(&self, id: Uuid) -> profile_ipc::IpcReceiver<FileManagerResult<ReadFileProgress>> {
+    fn send_msg(
+        &self,
+        id: Uuid,
+        chan: profile_generic_callback::GenericCallback<FileManagerResult<ReadFileProgress>>,
+    ) {
         let resource_threads = self.resource_threads();
-        let (chan, recv) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
         let origin = self.origin().immutable().clone();
         let msg = FileManagerThreadMsg::ReadFile(chan, id, origin);
         let _ = resource_threads.send(CoreResourceMsg::ToFileManager(msg));
-        recv
     }
 
     fn read_msg(
-        receiver: profile_ipc::IpcReceiver<FileManagerResult<ReadFileProgress>>,
+        receiver: generic_channel::GenericReceiver<FileManagerResult<ReadFileProgress>>,
     ) -> Result<Vec<u8>, ()> {
         let mut bytes = vec![];
 

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -2294,7 +2294,7 @@ impl GlobalScope {
     }
 
     fn read_msg(
-        receiver: generic_channel::GenericReceiver<FileManagerResult<ReadFileProgress>>,
+        receiver: profile_generic_channel::GenericReceiver<FileManagerResult<ReadFileProgress>>,
     ) -> Result<Vec<u8>, ()> {
         let mut bytes = vec![];
 

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -6,7 +6,6 @@ use std::cmp::{max, min};
 use std::ops::Range;
 
 use embedder_traits::{EmbedderControlId, EmbedderControlResponse, FilePickerRequest};
-use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use num_traits::ToPrimitive;
 use profile_traits::generic_callback::GenericCallback;
@@ -130,7 +129,7 @@ pub enum FileManagerThreadMsg {
 
     /// Read FileID-indexed file in chunks, optionally check URL validity based on boolean flag
     ReadFile(
-        IpcSender<FileManagerResult<ReadFileProgress>>,
+        GenericCallback<FileManagerResult<ReadFileProgress>>,
         Uuid,
         ImmutableOrigin,
     ),
@@ -157,7 +156,7 @@ pub enum FileManagerThreadMsg {
     /// Activate an internal FileID so it becomes valid as part of a Blob URL
     ActivateBlobURL(
         Uuid,
-        IpcSender<Result<(), BlobURLStoreError>>,
+        GenericSender<Result<(), BlobURLStoreError>>,
         ImmutableOrigin,
     ),
 

--- a/components/shared/profile/generic_callback.rs
+++ b/components/shared/profile/generic_callback.rs
@@ -5,6 +5,7 @@
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{SendError, SendResult};
+
 use crate::generic_channel::GenericReceiver;
 use crate::time::{ProfilerCategory, ProfilerChan};
 use crate::time_profile;
@@ -41,7 +42,7 @@ where
                 callback,
                 time_profiler_chan: time_profiler_chan.clone(),
             },
-            GenericReceiver::new(receiver, time_profiler_chan)
+            GenericReceiver::new(receiver, time_profiler_chan),
         ))
     }
 

--- a/components/shared/profile/generic_callback.rs
+++ b/components/shared/profile/generic_callback.rs
@@ -31,6 +31,20 @@ where
             time_profiler_chan,
         })
     }
+
+    pub fn new_blocking(
+        time_profiler_chan: ProfilerChan,
+    ) -> Result<(Self, servo_base::generic_channel::GenericReceiver<T>), SendError> {
+        let (callback, receiver) = servo_base::generic_channel::GenericCallback::new_blocking()?;
+        Ok((
+            GenericCallback {
+                callback,
+                time_profiler_chan,
+            },
+            receiver,
+        ))
+    }
+
     pub fn send(&self, value: T) -> SendResult {
         time_profile!(
             ProfilerCategory::IpcReceiver,

--- a/components/shared/profile/generic_callback.rs
+++ b/components/shared/profile/generic_callback.rs
@@ -5,7 +5,7 @@
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{SendError, SendResult};
-
+use crate::generic_channel::GenericReceiver;
 use crate::time::{ProfilerCategory, ProfilerChan};
 use crate::time_profile;
 
@@ -34,14 +34,14 @@ where
 
     pub fn new_blocking(
         time_profiler_chan: ProfilerChan,
-    ) -> Result<(Self, servo_base::generic_channel::GenericReceiver<T>), SendError> {
+    ) -> Result<(Self, GenericReceiver<T>), SendError> {
         let (callback, receiver) = servo_base::generic_channel::GenericCallback::new_blocking()?;
         Ok((
             GenericCallback {
                 callback,
-                time_profiler_chan,
+                time_profiler_chan: time_profiler_chan.clone(),
             },
-            receiver,
+            GenericReceiver::new(receiver, time_profiler_chan)
         ))
     }
 

--- a/components/shared/profile/generic_channel.rs
+++ b/components/shared/profile/generic_channel.rs
@@ -20,7 +20,10 @@ impl<T> GenericReceiver<T>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    pub(crate) fn new(receiver: generic_channel::GenericReceiver<T>, time_profile_chan: ProfilerChan) -> Self {
+    pub(crate) fn new(
+        receiver: generic_channel::GenericReceiver<T>,
+        time_profile_chan: ProfilerChan,
+    ) -> Self {
         Self {
             receiver,
             time_profile_chan,

--- a/components/shared/profile/generic_channel.rs
+++ b/components/shared/profile/generic_channel.rs
@@ -20,6 +20,13 @@ impl<T> GenericReceiver<T>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
+    pub(crate) fn new(receiver: generic_channel::GenericReceiver<T>, time_profile_chan: ProfilerChan) -> Self {
+        Self {
+            receiver,
+            time_profile_chan,
+        }
+    }
+
     pub fn recv(&self) -> Result<T, generic_channel::ReceiveError> {
         time_profile!(
             ProfilerCategory::IpcReceiver,


### PR DESCRIPTION
Replaces the IPC channels in the file/blob code with generic channels for better performance in single process mode. Also adds a `new_blocking` function for `GenericCallback` with profiling enabled to avoid using an additional crossbeam channel in the synchronous `read_file` function and to keep changes to the tests to a minimum.

Testing: Only replaces the IPC channels with generic channels, so no new tests should be required. The existent tests got modified to work with generic channels.
Fixes: #47671
