### PR TITLE
script: Implement `FontFace`'s `stretch` as a binding alias of `width`

### DIFF
--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -545,16 +545,6 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         self.validate_and_set_descriptors(new_descriptors)
     }
 
-    /// <https://drafts.csswg.org/css-font-loading/#dom-fontface-stretch>
-    fn Stretch(&self) -> DOMString {
-        self.Width()
-    }
-
-    /// <https://drafts.csswg.org/css-font-loading/#dom-fontface-stretch>
-    fn SetStretch(&self, value: DOMString) -> ErrorResult {
-        self.SetWidth(value)
-    }
-
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontface-width>
     fn Width(&self) -> DOMString {
         self.descriptors.borrow().width.clone()

--- a/components/script_bindings/webidls/FontFace.webidl
+++ b/components/script_bindings/webidls/FontFace.webidl
@@ -31,11 +31,7 @@ interface FontFace {
   attribute CSSOMString style;
   [SetterThrows]
   attribute CSSOMString weight;
-  // TODO: Once we support the `BindingAlias` extended attribute, we should remove the `stretch` attribute,
-  // and instead annotate the `width` attribute with `BindingAlias="stretch"`.
-  [SetterThrows]
-  attribute CSSOMString stretch;
-  [SetterThrows]
+  [SetterThrows, BindingAlias="stretch"]
   attribute CSSOMString width;
   [SetterThrows]
   attribute CSSOMString unicodeRange;


### PR DESCRIPTION
Now that `BindingAlias` has been implemented, we can use it.

Testing: Not needed, no behavior change
