### PR TITLE
script:  Reduce chance of redundant String allocation when parsing sandbox attribute

### DIFF
--- a/components/script/dom/html/embedded_content/htmliframeelement.rs
+++ b/components/script/dom/html/embedded_content/htmliframeelement.rs
@@ -837,7 +837,7 @@ impl HTMLIFrameElement {
                         .value()
                         .as_tokens()
                         .iter()
-                        .map(|atom| atom.to_string().to_ascii_lowercase())
+                        .map(|atom| atom.to_ascii_lowercase().to_string())
                         .collect();
                     parse_a_sandboxing_directive(&tokens)
                 });


### PR DESCRIPTION
When atom is already lowercased, [to_ascii_lowercase](https://docs.rs/string_cache/0.11.0/src/string_cache/atom.rs.html#422) from Atom does not allocate a String, but just clone an Atom which is cheap.
In this case we can just end up allocating one String instead of two. And sandbox attribute are normally lowercase.

Testing: No behaviour change.