### PR TITLE
script: Enable lints for script crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,10 @@ xpath = { package = "servo-xpath", version = "=0.6.0", path = "components/xpath"
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 [workspace.lints.clippy]
-manual_string_new = "deny"
+manual_string_new = "warn"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
 
 # RSA key generation could be very slow without compilation
 # optimizations, in development mode. Without optimizations, WPT might

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -78,8 +78,8 @@ webgpu = [
 ]
 webxr = ["webgl", "gamepad", "webxr-api", "script_bindings/webxr"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
+[lints]
+workspace = true
 
 [dependencies]
 aes = { workspace = true, optional = true }

--- a/components/script/css/stylesheet_loader.rs
+++ b/components/script/css/stylesheet_loader.rs
@@ -669,7 +669,7 @@ impl StyleStylesheetLoader for ElementStylesheetLoader<'_> {
                     media,
                     resolved_url.into(),
                     None,
-                    "".to_owned(),
+                    String::new(),
                 );
             },
             ElementStylesheetLoader::Asynchronous(AsynchronousStylesheetLoader {
@@ -689,7 +689,7 @@ impl StyleStylesheetLoader for ElementStylesheetLoader<'_> {
                         media,
                         resolved_url.into(),
                         None,
-                        "".to_owned()
+                        String::new()
                     );
                 });
                 let _ =

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5757,7 +5757,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             local_name.make_ascii_lowercase();
         }
         let name = LocalName::from(local_name);
-        let value = AttrValue::String("".to_owned());
+        let value = AttrValue::String(String::new());
 
         Ok(Attr::new(
             cx,
@@ -5783,7 +5783,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         let context = domname::Context::Attribute;
         let (namespace, prefix, local_name) =
             domname::validate_and_extract(namespace, &qualified_name, context)?;
-        let value = AttrValue::String("".to_owned());
+        let value = AttrValue::String(String::new());
         let qualified_name = LocalName::from(qualified_name);
         Ok(Attr::new(
             cx,

--- a/components/script/dom/document/websocket.rs
+++ b/components/script/dom/document/websocket.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::ptr::{self, NonNull};
 use std::rc::Rc;
@@ -126,7 +125,7 @@ impl WebSocket {
             clearing_buffer: Cell::new(false),
             callback,
             binary_type: Cell::new(BinaryType::Blob),
-            protocol: DomRefCell::new("".to_owned()),
+            protocol: Default::default(),
         }
     }
 
@@ -575,7 +574,7 @@ impl TaskOnce for CloseTask {
         // Step 3.
         let clean_close = !self.failed;
         let code = self.code.unwrap_or(close_code::NO_STATUS);
-        let reason = DOMString::from(self.reason.unwrap_or("".to_owned()));
+        let reason = DOMString::from(self.reason.unwrap_or_default());
         let close_event = CloseEvent::new(
             cx,
             &ws.global(),
@@ -623,7 +622,7 @@ impl TaskOnce for MessageReceivedTask {
             MessageData::Binary(data) => match ws.binary_type.get() {
                 BinaryType::Blob => {
                     let blob =
-                        Blob::new(cx, &global, BlobImpl::new_from_bytes(data, "".to_owned()));
+                        Blob::new(cx, &global, BlobImpl::new_from_bytes(data, String::new()));
                     blob.to_jsval(cx, message.handle_mut());
                 },
                 BinaryType::Arraybuffer => {

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -666,7 +666,7 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
     fn Referrer(&self) -> USVString {
         let r = self.request.borrow();
         USVString(match r.referrer {
-            Referrer::NoReferrer => String::from(""),
+            Referrer::NoReferrer => String::new(),
             Referrer::Client(_) => String::from("about:client"),
             Referrer::ReferrerUrl(ref u) => {
                 let u_c = u.clone();

--- a/components/script/dom/file/blob.rs
+++ b/components/script/dom/file/blob.rs
@@ -441,9 +441,9 @@ pub(crate) fn normalize_type_string(s: &str) -> String {
         s.to_ascii_lowercase()
         // match s_lower.parse() as Result<Mime, ()> {
         // Ok(_) => s_lower,
-        // Err(_) => "".to_string()
+        // Err(_) => String::new()
     } else {
-        "".to_string()
+        String::new()
     }
 }
 

--- a/components/script/dom/html/embedded_content/htmlimageelement.rs
+++ b/components/script/dom/html/embedded_content/htmlimageelement.rs
@@ -1648,7 +1648,7 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
                 let unparsed_url = &current_request.source_url;
                 match *unparsed_url {
                     Some(ref url) => url.clone(),
-                    None => USVString("".to_owned()),
+                    None => USVString(String::new()),
                 }
             },
         }

--- a/components/script/dom/html/embedded_content/htmlmediaelement.rs
+++ b/components/script/dom/html/embedded_content/htmlmediaelement.rs
@@ -673,7 +673,7 @@ impl HTMLMediaElement {
             network_state: Cell::new(NetworkState::Empty),
             ready_state: Cell::new(ReadyState::HaveNothing),
             src_object: Default::default(),
-            current_src: DomRefCell::new("".to_owned()),
+            current_src: Default::default(),
             generation_id: Cell::new(0),
             fired_loadeddata_event: Cell::new(false),
             error: Default::default(),

--- a/components/script/dom/html/form_controls/text_input.rs
+++ b/components/script/dom/html/form_controls/text_input.rs
@@ -697,7 +697,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                     )
                 } else {
                     KeyReaction::DispatchInput(
-                        Some("".to_string()),
+                        Some(String::new()),
                         IsComposing::NotComposing,
                         InputType::InsertFromPaste,
                     )

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -650,7 +650,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // Step 5: If fragment has no children, then append a new Text node whose data is the empty
         // string and node document is this's node document to fragment.
         if fragment.upcast::<Node>().children_count() == 0 {
-            let text_node = Text::new(cx, DOMString::from("".to_owned()), &document);
+            let text_node = Text::new(cx, DOMString::new(), &document);
 
             fragment
                 .upcast::<Node>()
@@ -1330,7 +1330,7 @@ impl VirtualMethods for HTMLElement {
                     element.update_nonce_internal_slot(nonce.to_owned(), cx.no_gc());
                 },
                 AttributeMutation::Removed => {
-                    element.update_nonce_internal_slot("".to_owned(), cx.no_gc());
+                    element.update_nonce_internal_slot(String::new(), cx.no_gc());
                 },
             },
             _ => {},

--- a/components/script/dom/html/links/htmlhyperlinkelementutils.rs
+++ b/components/script/dom/html/links/htmlhyperlinkelementutils.rs
@@ -220,7 +220,7 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
 
         USVString(match *self.get_url().borrow() {
             // Step 2. If this's url is null, return the empty string.
-            None => "".to_owned(),
+            None => String::new(),
             // Step 3. Return the serialization of this's url's origin.
             Some(ref url) => url.origin().ascii_serialization().into_owned(),
         })

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1912,7 +1912,7 @@ impl Node {
             base_uri,
             parent: self
                 .GetParentNode()
-                .map_or("".to_owned(), |node| node.unique_id(pipeline)),
+                .map_or(String::new(), |node| node.unique_id(pipeline)),
             node_type,
             is_top_level_document: node_type == NodeConstants::DOCUMENT_NODE,
             node_name: String::from(self.NodeName()),

--- a/components/script/dom/reporting/reportingendpoint.rs
+++ b/components/script/dom/reporting/reportingendpoint.rs
@@ -244,7 +244,7 @@ impl SendReportsToEndpoints for GlobalScope {
                 age: 0,
                 type_: r.type_.to_string(),
                 url: r.url.to_string(),
-                user_agent: "".to_owned(),
+                user_agent: String::new(),
                 body: r.body.clone().map(|b| b.into()),
             })
             // Step 2.2. Increment report’s attempts.

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -153,8 +153,8 @@ impl CspReporting for Option<CspList> {
             redirect_count: 0,
             destination: Destination::None,
             initiator: Initiator::None,
-            nonce: "".to_owned(),
-            integrity_metadata: "".to_owned(),
+            nonce: String::new(),
+            integrity_metadata: String::new(),
             parser_metadata: ParserMetadata::None,
         };
         // TODO: set correct navigation check type for form submission if applicable

--- a/components/script/dom/security/csppolicyviolationreport.rs
+++ b/components/script/dom/security/csppolicyviolationreport.rs
@@ -96,7 +96,7 @@ impl Convert<CSPViolationReportBody> for SecurityPolicyViolationReport {
             // TODO(37328): Why does /content-security-policy/reporting-api/
             // report-to-directive-allowed-in-meta.https.sub.html expect this to be
             // empty, yet the spec expects us to copy referrer from SecurityPolicyViolationReport
-            referrer: Some("".to_owned().into()),
+            referrer: Some(String::new().into()),
             statusCode: self.status_code,
             documentURL: self.document_url.into(),
             sourceFile: source_file,

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -169,7 +169,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
     fn SetStringAttribute(&self, _: DOMString) {}
     fn UsvstringAttribute(&self) -> USVString {
-        USVString("".to_owned())
+        USVString(String::new())
     }
     fn SetUsvstringAttribute(&self, _: USVString) {}
     fn ByteStringAttribute(&self) -> ByteString {
@@ -184,7 +184,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         Blob::new(
             cx,
             &self.global(),
-            BlobImpl::new_from_bytes(vec![], "".to_owned()),
+            BlobImpl::new_from_bytes(vec![], String::new()),
         )
     }
     fn SetInterfaceAttribute(&self, _: &Blob) {}
@@ -197,7 +197,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
     fn SetUnion2Attribute(&self, _: EventOrString) {}
     fn Union3Attribute(&self) -> EventOrUSVString {
-        EventOrUSVString::USVString(USVString("".to_owned()))
+        EventOrUSVString::USVString(USVString(String::new()))
     }
     fn SetUnion3Attribute(&self, _: EventOrUSVString) {}
     fn Union4Attribute(&self) -> StringOrUnsignedLong {
@@ -300,7 +300,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
     fn SetStringAttributeNullable(&self, _: Option<DOMString>) {}
     fn GetUsvstringAttributeNullable(&self) -> Option<USVString> {
-        Some(USVString("".to_owned()))
+        Some(USVString(String::new()))
     }
     fn SetUsvstringAttributeNullable(&self, _: Option<USVString>) {}
     fn SetBinaryRenamedAttribute(&self, _: DOMString) {}
@@ -325,7 +325,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         Some(Blob::new(
             cx,
             &self.global(),
-            BlobImpl::new_from_bytes(vec![], "".to_owned()),
+            BlobImpl::new_from_bytes(vec![], String::new()),
         ))
     }
     fn SetInterfaceAttributeNullable(&self, _: Option<&Blob>) {}
@@ -408,7 +408,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         DOMString::new()
     }
     fn ReceiveUsvstring(&self) -> USVString {
-        USVString("".to_owned())
+        USVString(String::new())
     }
     fn ReceiveByteString(&self) -> ByteString {
         ByteString::new(vec![])
@@ -420,7 +420,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         Blob::new(
             cx,
             &self.global(),
-            BlobImpl::new_from_bytes(vec![], "".to_owned()),
+            BlobImpl::new_from_bytes(vec![], String::new()),
         )
     }
     fn ReceiveAny(&self, _: MutableHandleValue) {}
@@ -467,7 +467,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         vec![Blob::new(
             cx,
             &self.global(),
-            BlobImpl::new_from_bytes(vec![], "".to_owned()),
+            BlobImpl::new_from_bytes(vec![], String::new()),
         )]
     }
     fn ReceiveUnionIdentity(&self, arg: UnionTypes::StringOrObject) -> UnionTypes::StringOrObject {
@@ -517,7 +517,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         Some(DOMString::new())
     }
     fn ReceiveNullableUsvstring(&self) -> Option<USVString> {
-        Some(USVString("".to_owned()))
+        Some(USVString(String::new()))
     }
     fn ReceiveNullableByteString(&self) -> Option<ByteString> {
         Some(ByteString::new(vec![]))
@@ -529,7 +529,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         Some(Blob::new(
             cx,
             &self.global(),
-            BlobImpl::new_from_bytes(vec![], "".to_owned()),
+            BlobImpl::new_from_bytes(vec![], String::new()),
         ))
     }
     fn ReceiveNullableObject(&self, return_value: MutableHandleObject) {
@@ -612,7 +612,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
                 unsignedLongLongValue: 0,
                 unsignedLongValue: 0,
                 unsignedShortValue: 0,
-                usvstringValue: USVString("".to_owned()),
+                usvstringValue: USVString(String::new()),
             }),
             doubleValue: None,
             enumValue: None,

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -209,7 +209,7 @@ impl RTCDataChannel {
                         let blob = Blob::new(
                             cx,
                             &global,
-                            BlobImpl::new_from_bytes(data, "".to_owned()),
+                            BlobImpl::new_from_bytes(data, String::new()),
                         );
                         blob.to_jsval(cx, message.handle_mut());
                     },

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -295,7 +295,7 @@ impl RTCPeerConnection {
                     cx,
                     &self.global(),
                     self,
-                    USVString::from("".to_owned()),
+                    USVString::from(String::new()),
                     &RTCDataChannelInit::empty(),
                     Some(channel_id),
                 );

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -63,7 +63,7 @@ impl XRInputSource {
             cx,
             window,
             0,
-            "".into(),
+            String::new(),
             "xr-standard".into(),
             (-1.0, 1.0),
             (0.0, 1.0),

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -997,7 +997,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                         self.text_response()
                     },
                     // Step 2
-                    _ => "".to_owned(),
+                    _ => String::new(),
                 }))
             },
             // Step 1

--- a/components/script/event_loop/devtools.rs
+++ b/components/script/event_loop/devtools.rs
@@ -720,7 +720,7 @@ pub(crate) fn handle_get_inner_or_outer_html(
                 return Some(html_dom_string.to_string());
             };
         }
-        Some("".to_owned())
+        Some(String::new())
     });
 
     reply.send(selector).unwrap();

--- a/components/script/event_loop/webdriver_handlers.rs
+++ b/components/script/event_loop/webdriver_handlers.rs
@@ -305,7 +305,7 @@ fn matching_links<'a>(
             let content = node
                 .downcast::<HTMLElement>()
                 .map(|element| element.InnerText())
-                .map_or("".to_owned(), String::from)
+                .map_or(String::new(), String::from)
                 .trim()
                 .to_owned();
             if partial {
@@ -1696,7 +1696,7 @@ pub(crate) fn handle_get_text(
                         element
                             .upcast::<Node>()
                             .GetTextContent()
-                            .map_or("".to_owned(), String::from)
+                            .map_or(String::new(), String::from)
                     })
             }),
         )

--- a/components/script/fetch/body.rs
+++ b/components/script/fetch/body.rs
@@ -911,11 +911,7 @@ fn run_blob_data_algorithm(
     bytes: Vec<u8>,
     mime: &[u8],
 ) -> Fallible<FetchedData> {
-    let mime_string = if let Ok(s) = String::from_utf8(mime.to_vec()) {
-        s
-    } else {
-        "".to_string()
-    };
+    let mime_string = String::from_utf8(mime.to_vec()).unwrap_or_default();
     let blob = Blob::new(
         cx,
         root,

--- a/components/script/modules/script_module.rs
+++ b/components/script/modules/script_module.rs
@@ -1114,9 +1114,9 @@ pub(crate) fn fetch_a_module_script_graph(
     // metadata is "not-parser-inserted", credentials mode is credentialsMode,
     // referrer policy is the empty string, and fetch priority is "auto".
     let options = ScriptFetchOptions {
-        integrity_metadata: "".into(),
+        integrity_metadata: String::new(),
         credentials_mode,
-        cryptographic_nonce: "".into(),
+        cryptographic_nonce: String::new(),
         parser_metadata: ParserMetadata::NotParserInserted,
         referrer_policy: ReferrerPolicy::EmptyString,
         render_blocking: false,

--- a/components/script/runtime/script_runtime.rs
+++ b/components/script/runtime/script_runtime.rs
@@ -329,7 +329,7 @@ unsafe extern "C" fn promise_rejection_tracker(
 #[expect(unsafe_code)]
 fn safely_convert_null_to_string(cx: &JSContext, str_: HandleString) -> DOMString {
     DOMString::from(match std::ptr::NonNull::new(*str_) {
-        None => "".to_owned(),
+        None => String::new(),
         Some(str_) => unsafe { jsstr_to_string(cx, str_) },
     })
 }


### PR DESCRIPTION
Inherits the `manual_string_new` (now set to `warn`, since we deny warnings in CI and don't want to fail compilation for it). It also moves the `cfg(crown)` to the workspace, since other crates will also need to use it.

Part of #47512

Testing: it compiles