### PR TITLE
script: Gracefully handle missing parent when getting origin details in `WindowProxy`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1919,17 +1919,14 @@ where
                     "Document origin retrieval after closure",
                 );
             },
-            ScriptToConstellationMessage::GetInternalAncestorOriginObjectsList(
+            ScriptToConstellationMessage::GetDocumentOriginDetails(
                 pipeline_id,
                 response_sender,
             ) => {
                 self.send_message_to_pipeline(
                     pipeline_id,
-                    ScriptThreadMessage::GetInternalAncestorOriginObjectsList(
-                        pipeline_id,
-                        response_sender,
-                    ),
-                    "Document ancestor origin objects list retrieval after closure",
+                    ScriptThreadMessage::GetDocumentOriginDetails(pipeline_id, response_sender),
+                    "Document ancestor origin details retrieval after closure",
                 );
             },
             ScriptToConstellationMessage::ServiceWorkerAlgorithm(algorithm) => {

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -163,8 +163,8 @@ mod from_script {
                 Self::GetBrowsingContextInfo(..) => target!("GetBrowsingContextInfo"),
                 Self::GetDocumentOrigin(..) => target!("GetDocumentOrigin"),
                 Self::IsCurrentlyFullyActive(..) => target!("IsCurrentlyFullyActive"),
-                Self::GetInternalAncestorOriginObjectsList(..) => {
-                    target!("GetInternalAncestorOriginObjectsList")
+                Self::GetDocumentOriginDetails(..) => {
+                    target!("GetDocumentOriginDetails")
                 },
                 Self::GetChildBrowsingContextId(..) => target!("GetChildBrowsingContextId"),
                 Self::LoadComplete => target!("LoadComplete"),

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -215,7 +215,9 @@ impl CspReporting for Option<CspList> {
             }
             // Cross-origin parents go via the constellation (slower)
             if let Some(parent_proxy) = window_proxy.parent() {
-                let Some(parent_origin) = parent_proxy.document_origin() else {
+                let Some((parent_origin, _)) =
+                    parent_proxy.document_origin_and_internal_ancestor_origin_objects_list()
+                else {
                     break;
                 };
                 let parent_origin = parent_origin.immutable().ascii_serialization();

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -900,30 +900,17 @@ impl WindowProxy {
         result
     }
 
-    pub(crate) fn document_origin(&self) -> Option<OriginSnapshot> {
+    pub(crate) fn document_origin_and_internal_ancestor_origin_objects_list(
+        &self,
+    ) -> Option<(OriginSnapshot, Vec<ImmutableOrigin>)> {
         let pipeline_id = self.currently_active()?;
         let (result_sender, result_receiver) = generic_channel::channel().unwrap();
         self.global()
             .script_to_constellation_chan()
-            .send(ScriptToConstellationMessage::GetDocumentOrigin(
+            .send(ScriptToConstellationMessage::GetDocumentOriginDetails(
                 pipeline_id,
                 result_sender,
             ))
-            .ok()?;
-        result_receiver.recv().ok()?
-    }
-
-    pub(crate) fn internal_ancestor_origin_objects_list(&self) -> Option<Vec<ImmutableOrigin>> {
-        let pipeline_id = self.currently_active()?;
-        let (result_sender, result_receiver) = generic_channel::channel().unwrap();
-        self.global()
-            .script_to_constellation_chan()
-            .send(
-                ScriptToConstellationMessage::GetInternalAncestorOriginObjectsList(
-                    pipeline_id,
-                    result_sender,
-                ),
-            )
             .ok()?;
         result_receiver.recv().ok()?
     }
@@ -949,14 +936,7 @@ impl WindowProxy {
         } else if let Some(parent_proxy) = self.parent() {
             // Step 4. Assert: parentDoc is fully active.
             assert!(parent_proxy.currently_active().is_some());
-
-            let origin = parent_proxy
-                .document_origin()
-                .expect("Must always be active");
-            let list = parent_proxy
-                .internal_ancestor_origin_objects_list()
-                .expect("Must always be active");
-            Some((origin, list))
+            parent_proxy.document_origin_and_internal_ancestor_origin_objects_list()
         } else {
             None
         }

--- a/components/script/event_loop/script_thread.rs
+++ b/components/script/event_loop/script_thread.rs
@@ -1726,11 +1726,8 @@ impl ScriptThread {
             ScriptThreadMessage::GetDocumentOrigin(pipeline_id, result_sender) => {
                 self.handle_get_document_origin(pipeline_id, result_sender);
             },
-            ScriptThreadMessage::GetInternalAncestorOriginObjectsList(
-                pipeline_id,
-                result_sender,
-            ) => {
-                self.handle_get_internal_ancestor_origin_objects_list(pipeline_id, result_sender);
+            ScriptThreadMessage::GetDocumentOriginDetails(pipeline_id, result_sender) => {
+                self.handle_get_origin_details(pipeline_id, result_sender);
             },
             ScriptThreadMessage::GetTitle(pipeline_id) => self.handle_get_title_msg(pipeline_id),
             ScriptThreadMessage::SetDocumentActivity(pipeline_id, activity) => {
@@ -2691,17 +2688,21 @@ impl ScriptThread {
         );
     }
 
-    fn handle_get_internal_ancestor_origin_objects_list(
+    fn handle_get_origin_details(
         &self,
         id: PipelineId,
-        result_sender: GenericSender<Option<Vec<ImmutableOrigin>>>,
+        result_sender: GenericSender<Option<(OriginSnapshot, Vec<ImmutableOrigin>)>>,
     ) {
-        let _ = result_sender.send(
-            self.documents
-                .borrow()
-                .find_document(id)
-                .and_then(|document| document.internal_ancestor_origin_objects_list().clone()),
-        );
+        let origin_details = self.documents.borrow().find_document(id).map(|document| {
+            (
+                document.origin().snapshot(),
+                document
+                    .internal_ancestor_origin_objects_list()
+                    .clone()
+                    .unwrap_or_default(),
+            )
+        });
+        let _ = result_sender.send(origin_details);
     }
 
     // exit_fullscreen creates a new JS promise object, so we need to have entered a realm

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -71,7 +71,7 @@ impl MixedMessage {
                 ScriptThreadMessage::RefreshCursor(id, ..) => Some(*id),
                 ScriptThreadMessage::GetTitle(id) => Some(*id),
                 ScriptThreadMessage::GetDocumentOrigin(id, _) => Some(*id),
-                ScriptThreadMessage::GetInternalAncestorOriginObjectsList(id, _) => Some(*id),
+                ScriptThreadMessage::GetDocumentOriginDetails(id, _) => Some(*id),
                 ScriptThreadMessage::SetDocumentActivity(id, ..) => Some(*id),
                 ScriptThreadMessage::SetThrottled(_, id, ..) => Some(*id),
                 ScriptThreadMessage::SetThrottledInContainingIframe(_, id, ..) => Some(*id),

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -726,8 +726,12 @@ pub enum ScriptToConstellationMessage {
     GetDocumentOrigin(PipelineId, GenericSender<Option<OriginSnapshot>>),
     /// If the document corresponding to the given pipeline is fully active
     IsCurrentlyFullyActive(PipelineId, GenericSender<bool>),
-    /// Get the internal ancestor origin objects list of the document corresponding to the given pipeline
-    GetInternalAncestorOriginObjectsList(PipelineId, GenericSender<Option<Vec<ImmutableOrigin>>>),
+    /// Get the origin and internal ancestor origin objects list of the `Document`
+    /// corresponding to the given `PipelineId`.
+    GetDocumentOriginDetails(
+        PipelineId,
+        GenericSender<Option<(OriginSnapshot, Vec<ImmutableOrigin>)>>,
+    ),
     /// All pending loads are complete, and the `load` event for this pipeline
     /// has been dispatched.
     LoadComplete,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -176,9 +176,13 @@ pub enum ScriptThreadMessage {
     /// Retrieve the origin of a document for a pipeline, in case a child needs to retrieve the
     /// origin of a parent in a different script thread.
     GetDocumentOrigin(PipelineId, GenericSender<Option<OriginSnapshot>>),
-    /// Retrieve the internal ancestor origin objects list of a document for a pipeline,
-    /// in case a child needs to retrieve the origin of a parent in a different script thread.
-    GetInternalAncestorOriginObjectsList(PipelineId, GenericSender<Option<Vec<ImmutableOrigin>>>),
+    /// Retrieve the origin and internal ancestor origin objects list of a
+    /// `Document` for a given `PipelineId`, in case a child needs to retrieve
+    /// the origin of a parent in a different event loop.
+    GetDocumentOriginDetails(
+        PipelineId,
+        GenericSender<Option<(OriginSnapshot, Vec<ImmutableOrigin>)>>,
+    ),
     /// Notifies script thread of a change to one of its document's activity
     SetDocumentActivity(PipelineId, DocumentActivity),
     /// Set whether to use less resources by running timers at a heavily limited rate.


### PR DESCRIPTION
When getting details of the origin (the origin and the internal
ancestor origin objects list), gracefully handle a missing parent. A
parent `Document` may be missing if it is in the process of shutting down and the
child hasn't ended yet. In addition, when getting both the parent origin
and the ancestor origin objects list, get both at the same time so that
they are both sampled at the same time and internally consistent. This
also reduces the amount of synchronous IPC.

This is a speculative fix for #47781. I was not able to reproduce this
locally. It is *very* timing sensitive. I created this fix by examining
the backtrace and the surrounding code. I believe this problem was
originally intrduced by #46056.

Testing: This panic is incredibly timing sensitive, so I was not able to 
successfully reproduce or test this issue.
Fixes: #47781.
