### PR TITLE
script_bindings: Enable unsafe operation linter

### DIFF
--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -81,4 +81,3 @@ webxr = ["gamepad", "webgl", "webxr-api"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
-unsafe_op_in_unsafe_fn = { level = "allow" }

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -203,19 +203,21 @@ impl<T: DomObject> ToJSValConvertible for DomRoot<T> {
 /// obj must point to a valid, non-null JS object.
 #[allow(clippy::result_unit_err)]
 pub unsafe fn get_dom_class(obj: *mut JSObject) -> Result<&'static DOMClass, ()> {
-    let clasp = get_object_class(obj);
-    if is_dom_class(&*clasp) {
-        trace!("plain old dom object");
-        let domjsclass: *const DOMJSClass = clasp as *const DOMJSClass;
-        return Ok(&(*domjsclass).dom_class);
-    }
-    if is_dom_proxy(obj) {
-        trace!("proxy dom object");
-        let dom_class: *const DOMClass = GetProxyHandlerExtra(obj) as *const DOMClass;
-        if dom_class.is_null() {
-            return Err(());
+    unsafe {
+        let clasp = get_object_class(obj);
+        if is_dom_class(&*clasp) {
+            trace!("plain old dom object");
+            let domjsclass: *const DOMJSClass = clasp as *const DOMJSClass;
+            return Ok(&(*domjsclass).dom_class);
         }
-        return Ok(&*dom_class);
+        if is_dom_proxy(obj) {
+            trace!("proxy dom object");
+            let dom_class: *const DOMClass = GetProxyHandlerExtra(obj) as *const DOMClass;
+            if dom_class.is_null() {
+                return Err(());
+            }
+            return Ok(&*dom_class);
+        }
     }
     trace!("not a dom object");
     Err(())
@@ -244,12 +246,14 @@ pub const DOM_OBJECT_SLOT: u32 = 0;
 /// obj must point to a valid non-null JS object.
 pub unsafe fn private_from_object(obj: *mut JSObject) -> *const libc::c_void {
     let mut value = UndefinedValue();
-    if is_dom_object(obj) {
-        JS_GetReservedSlot(obj, DOM_OBJECT_SLOT, &mut value);
-    } else {
-        debug_assert!(is_dom_proxy(obj));
-        GetProxyReservedSlot(obj, 0, &mut value);
-    };
+    unsafe {
+        if is_dom_object(obj) {
+            JS_GetReservedSlot(obj, DOM_OBJECT_SLOT, &mut value);
+        } else {
+            debug_assert!(is_dom_proxy(obj));
+            GetProxyReservedSlot(obj, 0, &mut value);
+        };
+    }
     if value.is_undefined() {
         ptr::null()
     } else {
@@ -279,23 +283,25 @@ pub unsafe fn private_from_proto_check(
     mut obj: *mut JSObject,
     proto_check: PrototypeCheck,
 ) -> Result<*const libc::c_void, ()> {
-    let dom_class = get_dom_class(obj).or_else(|_| {
-        if IsWrapper(obj) {
-            trace!("found wrapper");
-            obj = UnwrapObjectDynamic(obj, cx, /* stopAtWindowProxy = */ false);
-            if obj.is_null() {
-                trace!("unwrapping security wrapper failed");
-                Err(())
+    let dom_class = unsafe {
+        get_dom_class(obj).or_else(|_| {
+            if IsWrapper(obj) {
+                trace!("found wrapper");
+                obj = UnwrapObjectDynamic(obj, cx, /* stopAtWindowProxy = */ false);
+                if obj.is_null() {
+                    trace!("unwrapping security wrapper failed");
+                    Err(())
+                } else {
+                    assert!(!IsWrapper(obj));
+                    trace!("unwrapped successfully");
+                    get_dom_class(obj)
+                }
             } else {
-                assert!(!IsWrapper(obj));
-                trace!("unwrapped successfully");
-                get_dom_class(obj)
+                trace!("not a dom wrapper");
+                Err(())
             }
-        } else {
-            trace!("not a dom wrapper");
-            Err(())
-        }
-    })?;
+        })?
+    };
 
     let prototype_matches = match proto_check {
         PrototypeCheck::Derive(f) => (f)(dom_class),
@@ -306,7 +312,7 @@ pub unsafe fn private_from_proto_check(
 
     if prototype_matches {
         trace!("good prototype");
-        Ok(private_from_object(obj))
+        Ok(unsafe { private_from_object(obj) })
     } else {
         trace!("bad prototype");
         Err(())
@@ -344,7 +350,7 @@ pub unsafe fn root_from_object<T>(cx: &mut JSContext, obj: *mut JSObject) -> Res
 where
     T: DomObject + IDLInterface,
 {
-    native_from_object(cx, obj).map(|ptr| unsafe { DomRoot::from_ref(&*ptr) })
+    unsafe { native_from_object(cx, obj).map(|ptr| DomRoot::from_ref(&*ptr)) }
 }
 
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleValue`.
@@ -429,13 +435,15 @@ unsafe fn private_from_proto_check_static(
     obj: *mut JSObject,
     proto_check: fn(&'static DOMClass) -> bool,
 ) -> Result<*const libc::c_void, ()> {
-    let dom_class = get_dom_class(obj).map_err(|_| ())?;
-    if proto_check(dom_class) {
-        trace!("good prototype");
-        Ok(private_from_object(obj))
-    } else {
-        trace!("bad prototype");
-        Err(())
+    unsafe {
+        let dom_class = get_dom_class(obj).map_err(|_| ())?;
+        if proto_check(dom_class) {
+            trace!("good prototype");
+            Ok(private_from_object(obj))
+        } else {
+            trace!("bad prototype");
+            Err(())
+        }
     }
 }
 
@@ -449,7 +457,7 @@ pub unsafe fn native_from_object_static<T>(obj: *mut JSObject) -> Result<*const 
 where
     T: DomObject + IDLInterface,
 {
-    private_from_proto_check_static(obj, T::derives).map(|ptr| ptr as *const T)
+    unsafe { private_from_proto_check_static(obj, T::derives).map(|ptr| ptr as *const T) }
 }
 
 /// Get a `*const T` for a DOM object accessible from a `HandleValue`.
@@ -550,13 +558,15 @@ pub(crate) unsafe fn windowproxy_from_handlevalue<D: crate::DomTypes>(
         return Err(());
     }
     let object = v.get().to_object();
-    if !IsWindowProxy(object) {
-        return Err(());
+    unsafe {
+        if !IsWindowProxy(object) {
+            return Err(());
+        }
+        let mut value = UndefinedValue();
+        GetProxyReservedSlot(object, 0, &mut value);
+        let ptr = value.to_private() as *const D::WindowProxy;
+        Ok(DomRoot::from_ref(&*ptr))
     }
-    let mut value = UndefinedValue();
-    GetProxyReservedSlot(object, 0, &mut value);
-    let ptr = value.to_private() as *const D::WindowProxy;
-    Ok(DomRoot::from_ref(&*ptr))
 }
 
 #[allow(deprecated)]

--- a/components/script_bindings/interface.rs
+++ b/components/script_bindings/interface.rs
@@ -165,31 +165,33 @@ pub(crate) unsafe fn create_global_object<D: DomTypes>(
         // in select_compartment() below [1], preventing compartment reuse in either direction between this global
         // and any globals created with `use_system_compartment` set to false.
         // [1] IsSystemCompartment() → Realm::isSystem() → Realm::isSystem_ → principals == trustedPrincipals()
-        JS_SetTrustedPrincipals(cx, principal.as_raw());
+        unsafe { JS_SetTrustedPrincipals(cx, principal.as_raw()) };
     }
 
-    rval.set(JS_NewGlobalObject(
-        cx,
-        class,
-        principal.as_raw(),
-        OnNewGlobalHookOption::DontFireOnNewGlobalHook,
-        &*options,
-    ));
+    rval.set(unsafe {
+        JS_NewGlobalObject(
+            cx,
+            class,
+            principal.as_raw(),
+            OnNewGlobalHookOption::DontFireOnNewGlobalHook,
+            &*options,
+        )
+    });
     assert!(!rval.is_null());
 
     // Initialize the reserved slots before doing anything that can GC, to
     // avoid getting trace hooks called on a partially initialized object.
     let private_val = PrivateValue(private);
-    JS_SetReservedSlot(rval.get(), DOM_OBJECT_SLOT, &private_val);
+    unsafe { JS_SetReservedSlot(rval.get(), DOM_OBJECT_SLOT, &private_val) };
     let proto_array: Box<ProtoOrIfaceArray> =
         Box::new([ptr::null_mut::<JSObject>(); PrototypeList::PROTO_OR_IFACE_LENGTH]);
     let val = PrivateValue(Box::into_raw(proto_array) as *const libc::c_void);
-    JS_SetReservedSlot(rval.get(), DOM_PROTOTYPE_SLOT, &val);
+    unsafe { JS_SetReservedSlot(rval.get(), DOM_PROTOTYPE_SLOT, &val) };
 
     let mut cx = AutoRealm::new_from_handle(cx, rval.handle());
     let cx = &mut cx;
 
-    JS_FireOnNewGlobalObject(cx, rval.handle());
+    unsafe { JS_FireOnNewGlobalObject(cx, rval.handle()) };
 }
 
 /// Choose the compartment to create a new global object in.
@@ -202,13 +204,16 @@ fn select_compartment(cx: &mut js::context::JSContext, options: &mut RealmOption
     ) -> CompartmentIterResult {
         let data = data as *mut Data;
 
-        if !IsSharableCompartment(compartment) || IsSystemCompartment(compartment) {
-            return CompartmentIterResult::KeepGoing;
+        unsafe {
+            if !IsSharableCompartment(compartment) || IsSystemCompartment(compartment) {
+                return CompartmentIterResult::KeepGoing;
+            }
+
+            // Choose any sharable, non-system compartment in this context to allow
+            // same-agent documents to share JS and DOM objects.
+            *data = compartment;
         }
 
-        // Choose any sharable, non-system compartment in this context to allow
-        // same-agent documents to share JS and DOM objects.
-        *data = compartment;
         CompartmentIterResult::Stop
     }
 
@@ -478,13 +483,15 @@ unsafe extern "C" fn fun_to_string_hook(
     obj: RawHandleObject,
     _is_to_source: bool,
 ) -> *mut JSString {
-    let js_class = get_object_class(obj.get());
-    assert!(!js_class.is_null());
-    let repr = (*(js_class as *const NonCallbackInterfaceObjectClass)).representation;
-    assert!(!repr.is_empty());
-    let ret = JS_NewStringCopyN(cx, repr.as_ptr() as *const libc::c_char, repr.len());
-    assert!(!ret.is_null());
-    ret
+    unsafe {
+        let js_class = get_object_class(obj.get());
+        assert!(!js_class.is_null());
+        let repr = (*(js_class as *const NonCallbackInterfaceObjectClass)).representation;
+        assert!(!repr.is_empty());
+        let ret = JS_NewStringCopyN(cx, repr.as_ptr() as *const libc::c_char, repr.len());
+        assert!(!ret.is_null());
+        ret
+    }
 }
 
 fn create_unscopable_object(

--- a/components/script_bindings/principals.rs
+++ b/components/script_bindings/principals.rs
@@ -43,7 +43,7 @@ impl ServoJSPrincipals {
     /// `raw` must point to a valid JSPrincipals value.
     #[inline]
     pub unsafe fn from_raw_nonnull(raw: NonNull<JSPrincipals>) -> Self {
-        JS_HoldPrincipals(raw.as_ptr());
+        unsafe { JS_HoldPrincipals(raw.as_ptr()) };
         Self(raw)
     }
 
@@ -110,7 +110,7 @@ impl ServoJSPrincipalsRef<'_> {
     /// [`Self::from_raw_nonnull`].
     #[inline]
     pub unsafe fn from_raw_unchecked(raw: *mut JSPrincipals) -> Self {
-        Self::from_raw_nonnull(NonNull::new_unchecked(raw))
+        unsafe { Self::from_raw_nonnull(NonNull::new_unchecked(raw)) }
     }
 }
 

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -4,9 +4,6 @@
 
 //! Utilities for the implementation of JSAPI proxy handlers.
 
-// This is allowed on the crate level, but we are gradually fixing it over time.
-#![deny(unsafe_op_in_unsafe_fn)]
-
 use std::ffi::{CStr, CString};
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_char;

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -10,11 +10,11 @@ use std::slice;
 use js::context::{JSContext, RawJSContext};
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::gc::Handle;
-use js::glue::{AppendToIdVector, JS_GetReservedSlot, RUST_FUNCTION_VALUE_TO_JITINFO};
+use js::glue::{JS_GetReservedSlot, RUST_FUNCTION_VALUE_TO_JITINFO};
 use js::jsapi::{
     AtomToLinearString, CallArgs, ExceptionStackBehavior, GetLinearStringCharAt,
     GetLinearStringLength, GetNonCCWObjectGlobal, HandleId as RawHandleId,
-    HandleObject as RawHandleObject, Heap, JS_AtomizeStringN, JS_DeprecatedStringHasLatin1Chars,
+    HandleObject as RawHandleObject, Heap, JS_DeprecatedStringHasLatin1Chars,
     JS_GetLatin1StringCharsAndLength, JS_IsGlobalObject, JS_MayResolveStandardClass,
     JS_NewEnumerateStandardClasses, JS_ResolveStandardClass, JSAtom, JSAtomState, JSJitInfo,
     JSObject, JSPROP_ENUMERATE, JSTracer, MutableHandleIdVector as RawMutableHandleIdVector,
@@ -23,10 +23,11 @@ use js::jsapi::{
 use js::jsid::StringId;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::wrappers2::{
-    CallJitGetterOp, CallJitMethodOp, CallJitSetterOp, CallOriginalPromiseReject,
-    JS_ClearPendingException, JS_DefineProperty, JS_ForwardGetPropertyTo, JS_FreezeObject,
-    JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasOwnProperty, JS_HasProperty,
-    JS_HasPropertyById, JS_IsExceptionPending, JS_SetPendingException, JS_SetProperty,
+    AppendToIdVector, CallJitGetterOp, CallJitMethodOp, CallJitSetterOp, CallOriginalPromiseReject,
+    JS_AtomizeStringN, JS_ClearPendingException, JS_DefineProperty, JS_ForwardGetPropertyTo,
+    JS_FreezeObject, JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasOwnProperty,
+    JS_HasProperty, JS_HasPropertyById, JS_IsExceptionPending, JS_SetPendingException,
+    JS_SetProperty,
 };
 use js::rust::{
     HandleId, HandleObject, HandleValue, MutableHandleValue, Runtime, ToString, get_object_class,
@@ -104,10 +105,12 @@ pub(crate) const JSCLASS_DOM_GLOBAL: u32 = js::JSCLASS_USERBIT1;
 /// # Safety
 /// `global` must point to a valid, non-null JS object.
 pub(crate) unsafe fn get_proto_or_iface_array(global: *mut JSObject) -> *mut ProtoOrIfaceArray {
-    assert_ne!(((*get_object_class(global)).flags & JSCLASS_DOM_GLOBAL), 0);
-    let mut slot = UndefinedValue();
-    JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT, &mut slot);
-    slot.to_private() as *mut ProtoOrIfaceArray
+    unsafe {
+        assert_ne!(((*get_object_class(global)).flags & JSCLASS_DOM_GLOBAL), 0);
+        let mut slot = UndefinedValue();
+        JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT, &mut slot);
+        slot.to_private() as *mut ProtoOrIfaceArray
+    }
 }
 
 /// An array of *mut JSObject of size PROTO_OR_IFACE_LENGTH.
@@ -436,10 +439,10 @@ unsafe fn generic_call<D: DomTypes, const EXCEPTION_TO_REJECTION: bool>(
         *mut JSVal,
     ) -> bool,
 ) -> bool {
-    let args = CallArgs::from_vp(vp, argc);
+    let args = unsafe { CallArgs::from_vp(vp, argc) };
 
-    let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx.raw_cx_no_gc(), vp));
-    let proto_id = (*info).__bindgen_anon_2.protoID;
+    let info = unsafe { RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx.raw_cx_no_gc(), vp)) };
+    let proto_id = unsafe { (*info).__bindgen_anon_2.protoID };
 
     // <https://heycam.github.io/webidl/#es-operations>
     //
@@ -531,11 +534,11 @@ unsafe fn generic_call<D: DomTypes, const EXCEPTION_TO_REJECTION: bool>(
     rooted!(&in(cx) let obj = if thisobj.get().is_object() {
         thisobj.get().to_object()
     } else {
-        GetNonCCWObjectGlobal(JS_CALLEE(cx.raw_cx_no_gc(), vp).to_object_or_null())
+        unsafe { GetNonCCWObjectGlobal(JS_CALLEE(cx.raw_cx_no_gc(), vp).to_object_or_null()) }
     });
-    let depth = (*info).__bindgen_anon_3.depth as usize;
+    let depth = unsafe { (*info).__bindgen_anon_3.depth as usize };
     let proto_check = PrototypeCheck::Depth { depth, proto_id };
-    let this = match private_from_proto_check(cx, obj.get(), proto_check) {
+    let this = match unsafe { private_from_proto_check(cx, obj.get(), proto_check) } {
         Ok(val) => val,
         Err(()) => {
             // [this_implements_operation == false]
@@ -550,8 +553,10 @@ unsafe fn generic_call<D: DomTypes, const EXCEPTION_TO_REJECTION: bool>(
             //        have access to the current IDL operation's name and type
             //        and the target object's `CrossOriginProperties`.
             if lenient_this {
-                debug_assert!(!JS_IsExceptionPending(cx));
-                *vp = UndefinedValue();
+                unsafe {
+                    debug_assert!(!JS_IsExceptionPending(cx));
+                    *vp = UndefinedValue();
+                }
                 return true;
             } else {
                 throw_invalid_this(cx, proto_id);
@@ -589,7 +594,7 @@ unsafe fn generic_call<D: DomTypes, const EXCEPTION_TO_REJECTION: bool>(
         //  || cross_origin_operation == false && this_class_cross_origin == false]
     }
 
-    call(info, cx, obj.handle(), this as *mut libc::c_void, argc, vp)
+    unsafe { call(info, cx, obj.handle(), this as *mut libc::c_void, argc, vp) }
 }
 
 /// Generic method of IDL interface.
@@ -606,11 +611,13 @@ pub(crate) unsafe extern "C" fn generic_method<
     argc: libc::c_uint,
     vp: *mut JSVal,
 ) -> bool {
-    // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
-    let cx = &mut cx;
+    unsafe {
+        // SAFETY: it is safe to construct a JSContext from engine hook.
+        let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+        let cx = &mut cx;
 
-    generic_call::<D, EXCEPTION_TO_REJECTION>(cx, argc, vp, Policy::INFO, CallJitMethodOp)
+        generic_call::<D, EXCEPTION_TO_REJECTION>(cx, argc, vp, Policy::INFO, CallJitMethodOp)
+    }
 }
 
 /// Generic getter of IDL interface.
@@ -627,11 +634,13 @@ pub(crate) unsafe extern "C" fn generic_getter<
     argc: libc::c_uint,
     vp: *mut JSVal,
 ) -> bool {
-    // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
-    let cx = &mut cx;
+    unsafe {
+        // SAFETY: it is safe to construct a JSContext from engine hook.
+        let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+        let cx = &mut cx;
 
-    generic_call::<D, EXCEPTION_TO_REJECTION>(cx, argc, vp, Policy::INFO, CallJitGetterOp)
+        generic_call::<D, EXCEPTION_TO_REJECTION>(cx, argc, vp, Policy::INFO, CallJitGetterOp)
+    }
 }
 
 unsafe fn call_setter(
@@ -642,10 +651,12 @@ unsafe fn call_setter(
     argc: u32,
     vp: *mut JSVal,
 ) -> bool {
-    if !CallJitSetterOp(info, cx, handle, this, argc, vp) {
-        return false;
+    unsafe {
+        if !CallJitSetterOp(info, cx, handle, this, argc, vp) {
+            return false;
+        }
+        *vp = UndefinedValue();
     }
-    *vp = UndefinedValue();
     true
 }
 
@@ -659,11 +670,13 @@ pub(crate) unsafe extern "C" fn generic_setter<D: DomTypes, Policy: CallPolicy>(
     argc: libc::c_uint,
     vp: *mut JSVal,
 ) -> bool {
-    // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
-    let cx = &mut cx;
+    unsafe {
+        // SAFETY: it is safe to construct a JSContext from engine hook.
+        let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+        let cx = &mut cx;
 
-    generic_call::<D, false>(cx, argc, vp, Policy::INFO, call_setter)
+        generic_call::<D, false>(cx, argc, vp, Policy::INFO, call_setter)
+    }
 }
 
 /// <https://searchfox.org/mozilla-central/rev/7279a1df13a819be254fd4649e07c4ff93e4bd45/dom/bindings/BindingUtils.cpp#3300>
@@ -676,21 +689,23 @@ pub(crate) unsafe extern "C" fn generic_static_promise_method(
     argc: libc::c_uint,
     vp: *mut JSVal,
 ) -> bool {
-    // SAFETY: it is safe to construct a JSContext from engine hook.
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
-    let cx = &mut cx;
+    unsafe {
+        // SAFETY: it is safe to construct a JSContext from engine hook.
+        let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+        let cx = &mut cx;
 
-    let args = CallArgs::from_vp(vp, argc);
+        let args = CallArgs::from_vp(vp, argc);
 
-    let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx.raw_cx(), vp));
-    assert!(!info.is_null());
-    // TODO: we need safe wrappers for this in mozjs!
-    // assert_eq!((*info)._bitfield_1, JSJitInfo_OpType::StaticMethod as u8)
-    let static_fn = (*info).__bindgen_anon_1.staticMethod.unwrap();
-    if static_fn(cx.raw_cx(), argc, vp) {
-        return true;
+        let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx.raw_cx(), vp));
+        assert!(!info.is_null());
+        // TODO: we need safe wrappers for this in mozjs!
+        // assert_eq!((*info)._bitfield_1, JSJitInfo_OpType::StaticMethod as u8)
+        let static_fn = (*info).__bindgen_anon_1.staticMethod.unwrap();
+        if static_fn(cx.raw_cx(), argc, vp) {
+            return true;
+        }
+        exception_to_promise(cx, args.rval())
     }
-    exception_to_promise(cx, args.rval())
 }
 
 /// Coverts exception to promise rejection
@@ -720,14 +735,16 @@ pub(crate) fn exception_to_promise(cx: &mut JSContext, rval: RawMutableHandleVal
 /// `tracer` must point to a valid, non-null JSTracer.
 /// `obj` must point to a valid, non-null JSObject.
 pub(crate) unsafe fn trace_global(tracer: *mut JSTracer, obj: *mut JSObject) {
-    let array = get_proto_or_iface_array(obj);
-    for proto in (*array).iter() {
-        if !proto.is_null() {
-            trace_object(
-                tracer,
-                "prototype",
-                &*(proto as *const *mut JSObject as *const Heap<*mut JSObject>),
-            );
+    unsafe {
+        let array = get_proto_or_iface_array(obj);
+        for proto in (*array).iter() {
+            if !proto.is_null() {
+                trace_object(
+                    tracer,
+                    "prototype",
+                    &*(proto as *const *mut JSObject as *const Heap<*mut JSObject>),
+                );
+            }
         }
     }
 }
@@ -740,8 +757,10 @@ pub(crate) unsafe extern "C" fn enumerate_global(
     props: RawMutableHandleIdVector,
     enumerable_only: bool,
 ) -> bool {
-    assert!(JS_IsGlobalObject(obj.get()));
-    JS_NewEnumerateStandardClasses(cx, obj, props, enumerable_only)
+    unsafe {
+        assert!(JS_IsGlobalObject(obj.get()));
+        JS_NewEnumerateStandardClasses(cx, obj, props, enumerable_only)
+    }
 }
 
 /// Enumerate lazy properties of a global object that is a Window.
@@ -752,26 +771,28 @@ pub(crate) unsafe extern "C" fn enumerate_window<D: DomTypes>(
     props: RawMutableHandleIdVector,
     enumerable_only: bool,
 ) -> bool {
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
-    if !enumerate_global(cx.raw_cx(), obj, props, enumerable_only) {
-        return false;
-    }
-
-    if enumerable_only {
-        // All WebIDL interface names are defined as non-enumerable, so there's
-        // no point in checking them if we're only returning enumerable names.
-        return true;
-    }
-
-    let obj = Handle::from_raw(obj);
-    for (name, interface) in <D as DomHelpers<D>>::interface_map() {
-        if !(interface.enabled)(&mut cx, obj) {
-            continue;
-        }
-        let s = JS_AtomizeStringN(cx.raw_cx(), name.as_ptr() as *const c_char, name.len());
-        rooted!(&in(cx) let id = StringId(s));
-        if s.is_null() || !AppendToIdVector(props, id.handle().into()) {
+    unsafe {
+        let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+        if !enumerate_global(cx.raw_cx(), obj, props, enumerable_only) {
             return false;
+        }
+
+        if enumerable_only {
+            // All WebIDL interface names are defined as non-enumerable, so there's
+            // no point in checking them if we're only returning enumerable names.
+            return true;
+        }
+
+        let obj = Handle::from_raw(obj);
+        for (name, interface) in <D as DomHelpers<D>>::interface_map() {
+            if !(interface.enabled)(&mut cx, obj) {
+                continue;
+            }
+            let s = JS_AtomizeStringN(&cx, name.as_ptr() as *const c_char, name.len());
+            rooted!(&in(cx) let id = StringId(s));
+            if s.is_null() || !AppendToIdVector(props, id.handle()) {
+                return false;
+            }
         }
     }
     true
@@ -785,7 +806,7 @@ pub(crate) unsafe extern "C" fn may_resolve_global(
     id: PropertyKey,
     maybe_obj: *mut JSObject,
 ) -> bool {
-    JS_MayResolveStandardClass(names, id, maybe_obj)
+    unsafe { JS_MayResolveStandardClass(names, id, maybe_obj) }
 }
 
 /// Returns true if the resolve hook for this window may resolve the provided id.
@@ -796,14 +817,14 @@ pub(crate) unsafe extern "C" fn may_resolve_window<D: DomTypes>(
     id: PropertyKey,
     maybe_obj: *mut JSObject,
 ) -> bool {
-    if may_resolve_global(names, id, maybe_obj) {
+    if unsafe { may_resolve_global(names, id, maybe_obj) } {
         return true;
     }
 
     let cx = Runtime::get()
         .expect("There must be a JSContext active")
         .as_ptr();
-    let Ok(bytes) = latin1_bytes_from_id(cx, id) else {
+    let Ok(bytes) = (unsafe { latin1_bytes_from_id(cx, id) }) else {
         return false;
     };
 
@@ -817,8 +838,10 @@ pub(crate) unsafe extern "C" fn resolve_global(
     id: RawHandleId,
     rval: *mut bool,
 ) -> bool {
-    assert!(JS_IsGlobalObject(obj.get()));
-    JS_ResolveStandardClass(cx, obj, id, rval)
+    unsafe {
+        assert!(JS_IsGlobalObject(obj.get()));
+        JS_ResolveStandardClass(cx, obj, id, rval)
+    }
 }
 
 /// Resolve a lazy global property for a Window global.
@@ -828,24 +851,26 @@ pub(crate) unsafe extern "C" fn resolve_window<D: DomTypes>(
     id: RawHandleId,
     rval: *mut bool,
 ) -> bool {
-    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
-    if !resolve_global(cx.raw_cx(), obj, id, rval) {
-        return false;
-    }
+    unsafe {
+        let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+        if !resolve_global(cx.raw_cx(), obj, id, rval) {
+            return false;
+        }
 
-    if *rval {
-        return true;
-    }
-    let Ok(bytes) = latin1_bytes_from_id(cx.raw_cx(), *id) else {
-        *rval = false;
-        return true;
-    };
+        if *rval {
+            return true;
+        }
+        let Ok(bytes) = latin1_bytes_from_id(cx.raw_cx(), *id) else {
+            *rval = false;
+            return true;
+        };
 
-    if let Some(interface) = <D as DomHelpers<D>>::interface_map().get(bytes) {
-        (interface.define)(&mut cx, Handle::from_raw(obj));
-        *rval = true;
-    } else {
-        *rval = false;
+        if let Some(interface) = <D as DomHelpers<D>>::interface_map().get(bytes) {
+            (interface.define)(&mut cx, Handle::from_raw(obj));
+            *rval = true;
+        } else {
+            *rval = false;
+        }
     }
     true
 }
@@ -860,13 +885,13 @@ unsafe fn latin1_bytes_from_id(cx: *mut RawJSContext, id: jsid) -> Result<&'stat
     }
 
     let string = id.to_string();
-    if !JS_DeprecatedStringHasLatin1Chars(string) {
+    if !unsafe { JS_DeprecatedStringHasLatin1Chars(string) } {
         return Err(());
     }
     let mut length = 0;
-    let ptr = JS_GetLatin1StringCharsAndLength(cx, ptr::null(), string, &mut length);
+    let ptr = unsafe { JS_GetLatin1StringCharsAndLength(cx, ptr::null(), string, &mut length) };
     assert!(!ptr.is_null());
-    Ok(slice::from_raw_parts(ptr, length))
+    Ok(unsafe { slice::from_raw_parts(ptr, length) })
 }
 
 /// Returns a JSVal representing the frozen JavaScript array


### PR DESCRIPTION
This removes the last few remaining violations of this linting check. Removing these is required to eventually inherit all linter configurations from the root Cargo.toml

Part of #47512
Part of #35955

Testing: it compiles