### PR TITLE
constellation: Move `BrowsingContextGroup` to `ConstellationWebView`

### DIFF
--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -5,7 +5,7 @@
 use embedder_traits::ViewportDetails;
 use log::warn;
 use rustc_hash::{FxHashMap, FxHashSet};
-use servo_base::id::{BrowsingContextGroupId, BrowsingContextId, PipelineId, WebViewId};
+use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 
 use crate::pipeline::Pipeline;
 
@@ -39,9 +39,6 @@ pub struct NewBrowsingContextInfo {
 /// sorted reverse chronologically: in particular prev.pop() is the latest
 /// past entry, and next.pop() is the earliest future entry.
 pub struct BrowsingContext {
-    /// The browsing context group id where the top-level of this bc is found.
-    pub bc_group_id: BrowsingContextGroupId,
-
     /// The browsing context id.
     pub id: BrowsingContextId,
 
@@ -78,7 +75,6 @@ impl BrowsingContext {
     /// Note this just creates the browsing context, it doesn't add it to the constellation's set of browsing contexts.
     #[expect(clippy::too_many_arguments)]
     pub fn new(
-        bc_group_id: BrowsingContextGroupId,
         id: BrowsingContextId,
         webview_id: WebViewId,
         pipeline_id: PipelineId,
@@ -91,7 +87,6 @@ impl BrowsingContext {
         let mut pipelines = FxHashSet::default();
         pipelines.insert(pipeline_id);
         BrowsingContext {
-            bc_group_id,
             id,
             webview_id,
             viewport_details,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -85,7 +85,7 @@
 //! See <https://github.com/servo/servo/issues/14704>
 
 use std::borrow::ToOwned;
-use std::cell::{Cell, OnceCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
@@ -144,10 +144,9 @@ use servo_base::generic_channel::{
     GenericCallback, GenericSend, GenericSender, RoutedReceiver, SendError,
 };
 use servo_base::id::{
-    BrowsingContextGroupId, BrowsingContextId, CONSTELLATION_PIPELINE_NAMESPACE_ID,
-    FIRST_CONTENT_PIPELINE_NAMESPACE_ID, HistoryStateId, MessagePortId, MessagePortRouterId,
-    PainterId, PipelineId, PipelineNamespace, PipelineNamespaceId, PipelineNamespaceRequest,
-    ScriptEventLoopId, WebViewId,
+    BrowsingContextId, CONSTELLATION_PIPELINE_NAMESPACE_ID, FIRST_CONTENT_PIPELINE_NAMESPACE_ID,
+    HistoryStateId, MessagePortId, MessagePortRouterId, PainterId, PipelineId, PipelineNamespace,
+    PipelineNamespaceId, PipelineNamespaceRequest, ScriptEventLoopId, WebViewId,
 };
 use servo_base::threadboost::{BoostAffinity, ThreadPriority};
 #[cfg(feature = "bluetooth")]
@@ -243,11 +242,8 @@ struct WebRenderWGPU {
 /// A browsing context group.
 ///
 /// <https://html.spec.whatwg.org/multipage/#browsing-context-group>
-#[derive(Clone, Default)]
-struct BrowsingContextGroup {
-    /// A browsing context group holds a set of top-level browsing contexts.
-    top_level_browsing_context_set: FxHashSet<WebViewId>,
-
+#[derive(Default)]
+pub(crate) struct BrowsingContextGroup {
     /// The set of all event loops in this BrowsingContextGroup.
     /// We store the event loops in a map
     /// indexed by registered domain name (as a `Host`) to event loops.
@@ -260,6 +256,23 @@ struct BrowsingContextGroup {
     /// The set of all WebGPU channels in this BrowsingContextGroup.
     #[cfg(feature = "webgpu")]
     webgpus: HashMap<Host, WebGPU>,
+}
+
+impl Drop for BrowsingContextGroup {
+    fn drop(&mut self) {
+        #[cfg(feature = "webgpu")]
+        for webgpu in self.webgpus.values() {
+            // Request that the WebGPU exit, but do not wait for it to do so. We are explicitly
+            // avoiding a synchronous wait here in the middle of Constellation operation. If
+            // it becomes necessary in the future these receivers could be waited on asynchronously
+            // via polling.
+            if let Some((sender, _)) = generic_channel::oneshot() &&
+                let Err(error) = webgpu.exit(sender)
+            {
+                warn!("Failed to request WebGPU exit: {error}.");
+            }
+        }
+    }
 }
 
 struct WorkerAnimationFrameProvider {
@@ -420,14 +433,6 @@ pub struct Constellation<STF, SWF> {
 
     /// The set of all the browsing contexts in the browser.
     browsing_contexts: FxHashMap<BrowsingContextId, BrowsingContext>,
-
-    /// A user agent holds a a set of browsing context groups.
-    ///
-    /// <https://html.spec.whatwg.org/multipage/#browsing-context-group-set>
-    browsing_context_group_set: FxHashMap<BrowsingContextGroupId, BrowsingContextGroup>,
-
-    /// The Id counter for BrowsingContextGroup.
-    browsing_context_group_next_id: u32,
 
     /// Pipeline IDs are namespaced in order to avoid name collisions,
     /// and the namespaces are allocated by the constellation.
@@ -688,8 +693,6 @@ where
                     private_storage_threads: state.private_storage_threads,
                     system_font_service: state.system_font_service,
                     sw_managers: Default::default(),
-                    browsing_context_group_set: Default::default(),
-                    browsing_context_group_next_id: Default::default(),
                     message_ports: Default::default(),
                     message_port_routers: Default::default(),
                     broadcast_channels: Default::default(),
@@ -820,93 +823,45 @@ where
         pipeline_namespace_id
     }
 
-    fn next_browsing_context_group_id(&mut self) -> BrowsingContextGroupId {
-        let id = self.browsing_context_group_next_id;
-        self.browsing_context_group_next_id += 1;
-        BrowsingContextGroupId(id)
+    fn browsing_context_group_for_webview_id(
+        &self,
+        webview_id: &WebViewId,
+    ) -> Option<Rc<RefCell<BrowsingContextGroup>>> {
+        self.webviews
+            .get(webview_id)
+            .map(ConstellationWebView::browsing_context_group)
     }
 
     fn get_event_loop(
         &self,
         host: &Host,
         webview_id: &WebViewId,
-        opener: &Option<BrowsingContextId>,
     ) -> Result<Weak<EventLoop>, &'static str> {
-        let bc_group = match opener {
-            Some(browsing_context_id) => {
-                let opener = self
-                    .browsing_contexts
-                    .get(browsing_context_id)
-                    .ok_or("Opener was closed before the openee started")?;
-                self.browsing_context_group_set
-                    .get(&opener.bc_group_id)
-                    .ok_or("Opener belongs to an unknown browsing context group")?
-            },
-            None => self
-                .browsing_context_group_set
-                .values()
-                .filter(|bc_group| {
-                    bc_group
-                        .top_level_browsing_context_set
-                        .contains(webview_id)
-                })
-                .last()
-                .ok_or(
-                    "Trying to get an event-loop for a top-level belonging to an unknown browsing context group",
-                )?,
+        let Some(browsing_context_group) = self.browsing_context_group_for_webview_id(webview_id)
+        else {
+            return Err("Trying to get an event-loop for an unknown WebView");
         };
-        bc_group
+        browsing_context_group
+            .borrow()
             .event_loops
             .get(host)
             .ok_or("Trying to get an event-loop from an unknown browsing context group")
             .cloned()
     }
 
-    fn set_event_loop(
-        &mut self,
-        event_loop: &Rc<EventLoop>,
-        host: Host,
-        webview_id: WebViewId,
-        opener: Option<BrowsingContextId>,
-    ) {
-        let relevant_top_level = if let Some(opener) = opener {
-            match self.browsing_contexts.get(&opener) {
-                Some(opener) => opener.webview_id,
-                None => {
-                    warn!("Setting event-loop for an unknown auxiliary");
-                    return;
-                },
-            }
-        } else {
-            webview_id
+    fn set_event_loop(&mut self, event_loop: &Rc<EventLoop>, host: Host, webview_id: &WebViewId) {
+        let Some(browsing_context_group) = self.browsing_context_group_for_webview_id(webview_id)
+        else {
+            return warn!("Trying to add an event loop to an unknown WebView ({webview_id})");
         };
-        let maybe_bc_group_id = self
-            .browsing_context_group_set
-            .iter()
-            .filter_map(|(id, bc_group)| {
-                if bc_group
-                    .top_level_browsing_context_set
-                    .contains(&webview_id)
-                {
-                    Some(*id)
-                } else {
-                    None
-                }
-            })
-            .last();
-        let Some(bc_group_id) = maybe_bc_group_id else {
-            return warn!("Trying to add an event-loop to an unknown browsing context group");
-        };
-        if let Some(bc_group) = self.browsing_context_group_set.get_mut(&bc_group_id) &&
-            bc_group
-                .event_loops
-                .insert(host.clone(), Rc::downgrade(event_loop))
-                .is_some_and(|old_event_loop| old_event_loop.strong_count() != 0)
+
+        if browsing_context_group
+            .borrow_mut()
+            .event_loops
+            .insert(host.clone(), Rc::downgrade(event_loop))
+            .is_some_and(|old_event_loop| old_event_loop.strong_count() != 0)
         {
-            warn!(
-                "Double-setting an event-loop for {:?} at {:?}",
-                host, relevant_top_level
-            );
+            warn!("Double-setting an event loop for {host:?} in {webview_id:?}");
         }
     }
 
@@ -914,7 +869,6 @@ where
         &self,
         load_data: &LoadData,
         webview_id: WebViewId,
-        opener: Option<BrowsingContextId>,
         parent_pipeline_id: Option<PipelineId>,
         registered_domain_name: &Option<Host>,
     ) -> Option<Rc<EventLoop>> {
@@ -952,7 +906,7 @@ where
             return None;
         };
 
-        self.get_event_loop(registered_domain_name, &webview_id, &opener)
+        self.get_event_loop(registered_domain_name, &webview_id)
             .ok()?
             .upgrade()
     }
@@ -960,7 +914,6 @@ where
     fn get_or_create_event_loop_for_new_pipeline(
         &mut self,
         webview_id: WebViewId,
-        opener: Option<BrowsingContextId>,
         parent_pipeline_id: Option<PipelineId>,
         load_data: &LoadData,
         is_private: bool,
@@ -977,7 +930,6 @@ where
         if let Some(event_loop) = self.get_event_loop_for_new_pipeline(
             load_data,
             webview_id,
-            opener,
             parent_pipeline_id,
             &registered_domain_name,
         ) {
@@ -986,7 +938,7 @@ where
 
         let event_loop = EventLoop::spawn(self, is_private)?;
         if let Some(registered_domain_name) = registered_domain_name {
-            self.set_event_loop(&event_loop, registered_domain_name, webview_id, opener);
+            self.set_event_loop(&event_loop, registered_domain_name, &webview_id);
         }
         Ok(event_loop)
     }
@@ -1027,7 +979,6 @@ where
 
         let event_loop = match self.get_or_create_event_loop_for_new_pipeline(
             webview_id,
-            opener,
             parent_pipeline_id,
             &load_data,
             is_private,
@@ -1146,32 +1097,10 @@ where
         inherited_secure_context: Option<bool>,
         throttled: bool,
     ) {
+        debug!("{browsing_context_id}: Creating new browsing context");
         let Some(webview) = self.webviews.get_mut(&webview_id) else {
             println!("Adding BrowsingContext for unknown WebView: {webview_id:?}");
             return;
-        };
-
-        debug!("{browsing_context_id}: Creating new browsing context");
-        let bc_group_id = match self
-            .browsing_context_group_set
-            .iter_mut()
-            .filter_map(|(id, bc_group)| {
-                if bc_group
-                    .top_level_browsing_context_set
-                    .contains(&webview_id)
-                {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .last()
-        {
-            Some(id) => *id,
-            None => {
-                warn!("Top-level was unexpectedly removed from its top_level_browsing_context_set");
-                return;
-            },
         };
 
         // Override the viewport details if we have a pending change for that browsing context.
@@ -1179,7 +1108,6 @@ where
             .take_pending_viewport_details(&browsing_context_id)
             .unwrap_or(viewport_details);
         let browsing_context = BrowsingContext::new(
-            bc_group_id,
             browsing_context_id,
             webview_id,
             pipeline_id,
@@ -1996,15 +1924,15 @@ where
             #[cfg(feature = "webgpu")]
             ScriptToConstellationMessage::RequestAdapter(response_sender, options, ids) => self
                 .handle_wgpu_request(
+                    webview_id,
                     source_pipeline_id,
-                    BrowsingContextId::from(webview_id),
                     ScriptToConstellationMessage::RequestAdapter(response_sender, options, ids),
                 ),
             #[cfg(feature = "webgpu")]
             ScriptToConstellationMessage::GetWebGPUChan(response_sender) => self
                 .handle_wgpu_request(
+                    webview_id,
                     source_pipeline_id,
-                    BrowsingContextId::from(webview_id),
                     ScriptToConstellationMessage::GetWebGPUChan(response_sender),
                 ),
             ScriptToConstellationMessage::TitleChanged(pipeline, title) => {
@@ -2098,15 +2026,15 @@ where
     #[cfg(feature = "webgpu")]
     fn handle_wgpu_request(
         &mut self,
+        webview_id: WebViewId,
         source_pipeline_id: PipelineId,
-        browsing_context_id: BrowsingContextId,
         request: ScriptToConstellationMessage,
     ) {
         use webgpu::start_webgpu_thread;
 
-        let browsing_context_group_id = match self.browsing_contexts.get(&browsing_context_id) {
-            Some(bc) => &bc.bc_group_id,
-            None => return warn!("Browsing context not found"),
+        let Some(browsing_context_group) = self.browsing_context_group_for_webview_id(&webview_id)
+        else {
+            return warn!("WebView ({webview_id:?}) not found when handling WebGPU request");
         };
         let Some(source_pipeline) = self.pipelines.get(&source_pipeline_id) else {
             return warn!("{source_pipeline_id}: ScriptMsg from closed pipeline");
@@ -2114,14 +2042,8 @@ where
         let Some(host) = registered_domain_name(&source_pipeline.url) else {
             return warn!("Invalid host url");
         };
-        let browsing_context_group = if let Some(bcg) = self
-            .browsing_context_group_set
-            .get_mut(browsing_context_group_id)
-        {
-            bcg
-        } else {
-            return warn!("Browsing context group not found");
-        };
+
+        let mut browsing_context_group = browsing_context_group.borrow_mut();
         let webgpu_chan = match browsing_context_group.webgpus.entry(host) {
             Entry::Vacant(v) => start_webgpu_thread(
                 self.paint_proxy.cross_process_paint_api.clone(),
@@ -2889,27 +2811,27 @@ where
 
         debug!("Exiting WebGPU threads.");
         #[cfg(feature = "webgpu")]
-        let receivers = self
-            .browsing_context_group_set
-            .values()
-            .flat_map(|browsing_context_group| {
-                browsing_context_group.webgpus.values().map(|webgpu| {
+        {
+            let receivers: Vec<_> = self
+                .webviews
+                .values()
+                .flat_map(|webview| {
+                    // This `take` is necessary as it ensures that WebViews that
+                    // share a BrowsingContextGroup don't have their WebGPU
+                    // entries processed more than once.
+                    std::mem::take(&mut webview.browsing_context_group().borrow_mut().webgpus)
+                })
+                .filter_map(|(_, webgpu)| {
                     let (sender, receiver) =
                         generic_channel::oneshot().expect("Failed to create IPC channel!");
-                    if let Err(e) = webgpu.exit(sender) {
-                        warn!("Exit WebGPU Thread failed ({})", e);
-                        None
-                    } else {
-                        Some(receiver)
-                    }
+                    webgpu.exit(sender).is_ok().then_some(receiver)
                 })
-            })
-            .flatten();
+                .collect();
 
-        #[cfg(feature = "webgpu")]
-        for receiver in receivers {
-            if let Err(e) = receiver.recv() {
-                warn!("Failed to receive exit response from WebGPU ({:?})", e);
+            for receiver in receivers {
+                if let Err(error) = receiver.recv() {
+                    warn!("Failed to receive exit response from WebGPU: {error:?}.");
+                }
             }
         }
 
@@ -3302,8 +3224,13 @@ where
 
         // Register this new top-level browsing context id as a webview and set
         // its focused browsing context to be itself.
-        let mut new_webview =
-            ConstellationWebView::new(webview_id, browsing_context_id, user_content_manager_id);
+        let mut new_webview = ConstellationWebView::new(
+            webview_id,
+            // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context-group
+            Rc::new(RefCell::new(BrowsingContextGroup::default())),
+            browsing_context_id,
+            user_content_manager_id,
+        );
         new_webview.add_pending_change(SessionHistoryChange {
             webview_id,
             browsing_context_id,
@@ -3318,15 +3245,6 @@ where
             viewport_details,
         });
         self.webviews.insert(webview_id, new_webview);
-
-        // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context-group
-        let mut new_bc_group: BrowsingContextGroup = Default::default();
-        let new_bc_group_id = self.next_browsing_context_group_id();
-        new_bc_group
-            .top_level_browsing_context_set
-            .insert(webview_id);
-        self.browsing_context_group_set
-            .insert(new_bc_group_id, new_bc_group);
 
         self.new_pipeline(
             pipeline_id,
@@ -3350,15 +3268,26 @@ where
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-top-level-traversable>
     fn handle_close_top_level_browsing_context(&mut self, webview_id: WebViewId) {
         debug!("{webview_id}: Closing");
-        let browsing_context_id = BrowsingContextId::from(webview_id);
-        // Step 5. Remove traversable from the user agent's top-level traversable set.
-        let browsing_context =
-            self.close_browsing_context(webview_id, browsing_context_id, ExitPipelineMode::Normal);
 
-        // Any queued history traversal requests are never going to finish at this point,
-        // so notify the embedder that they are now finished.
-        let webview = self.webviews.remove(&webview_id);
-        if let Some(mut webview) = webview {
+        // Step 1. Let browsingContext be traversable's active browsing context.
+        let browsing_context_id = BrowsingContextId::from(webview_id);
+        // Step 2. For each historyEntry in traversable's session history
+        // Step 2.1 Let document be historyEntry's document.
+        // Step 2.2 If document is not null, then destroy a document and its
+        // descendants given document.
+
+        // Step 3. Remove browsingContext.
+        self.close_browsing_context(webview_id, browsing_context_id, ExitPipelineMode::Normal);
+
+        // Step 4. Remove traversable from the user interface (e.g., close or
+        // hide its tab in a tabbed browser).
+        self.constellation_to_embedder_proxy
+            .send(ConstellationToEmbedderMsg::WebViewClosed(webview_id));
+
+        // Step 5. Remove traversable from the user agent's top-level traversable set.
+        if let Some(mut webview) = self.webviews.remove(&webview_id) {
+            // Any queued history traversal requests are never going to finish at this point,
+            // so notify the embedder that they are now finished.
             if let Some(ongoing_request) = webview.ongoing_history_traversal_request {
                 self.notify_embedder_of_completed_session_history_traversal_request(
                     &ongoing_request.traversal_request,
@@ -3367,37 +3296,6 @@ where
             for request in webview.session_history_traversal_request_queue.drain(..) {
                 self.notify_embedder_of_completed_session_history_traversal_request(&request);
             }
-        }
-
-        // Step 4. Remove traversable from the user interface (e.g., close or hide its tab in a tabbed browser).
-        self.constellation_to_embedder_proxy
-            .send(ConstellationToEmbedderMsg::WebViewClosed(webview_id));
-
-        let Some(browsing_context) = browsing_context else {
-            return warn!(
-                "fn handle_close_top_level_browsing_context {}: Closing twice",
-                browsing_context_id
-            );
-        };
-        // Step 3. Remove browsingContext.
-        //
-        // Steps are now for https://html.spec.whatwg.org/multipage/#bcg-remove
-        let bc_group_id = browsing_context.bc_group_id;
-        // Step 2. Let group be browsingContext's group.
-        let Some(bc_group) = self.browsing_context_group_set.get_mut(&bc_group_id) else {
-            // Step 1. Assert: browsingContext's group is non-null.
-            warn!("{}: Browsing context group not found!", bc_group_id);
-            return;
-        };
-        // Step 4. Remove browsingContext from group's browsing context set.
-        if !bc_group.top_level_browsing_context_set.remove(&webview_id) {
-            warn!("{webview_id}: Top-level browsing context not found in {bc_group_id}",);
-        }
-        // Step 5. If group's browsing context set is empty, then remove group
-        // from the user agent's browsing context group set.
-        if bc_group.top_level_browsing_context_set.is_empty() {
-            self.browsing_context_group_set
-                .remove(&browsing_context.bc_group_id);
         }
 
         debug!("{webview_id}: Closed");
@@ -3654,6 +3552,14 @@ where
             response_sender,
         } = load_info;
 
+        let Some(browsing_context_group) =
+            self.browsing_context_group_for_webview_id(&opener_webview_id)
+        else {
+            warn!("Opener WebView ({opener_webview_id:?}) not found for new auxiliary WebView");
+            let _ = response_sender.send(None);
+            return;
+        };
+
         let Some((webview_id_sender, webview_id_receiver)) = generic_channel::channel() else {
             warn!("Failed to create channel");
             let _ = response_sender.send(None);
@@ -3719,6 +3625,7 @@ where
 
         let mut new_webview = ConstellationWebView::new(
             new_webview_id,
+            browsing_context_group,
             new_browsing_context_id,
             user_content_manager_id,
         );
@@ -3737,17 +3644,6 @@ where
             viewport_details,
         });
         self.webviews.insert(new_webview_id, new_webview);
-
-        // https://html.spec.whatwg.org/multipage/#bcg-append
-        let Some(opener) = self.browsing_contexts.get(&opener_browsing_context_id) else {
-            return warn!("Trying to append an unknown auxiliary to a browsing context group");
-        };
-        let Some(bc_group) = self.browsing_context_group_set.get_mut(&opener.bc_group_id) else {
-            return warn!("Trying to add a top-level to an unknown group.");
-        };
-        bc_group
-            .top_level_browsing_context_set
-            .insert(new_webview_id);
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -5873,7 +5769,7 @@ where
     #[servo_tracing::instrument(skip_all)]
     fn handle_theme_change(&mut self, webview_id: WebViewId, theme: Theme) {
         let Some(webview) = self.webviews.get_mut(&webview_id) else {
-            warn!("Received theme change request for uknown WebViewId: {webview_id:?}");
+            warn!("Received theme change request for unknown WebViewId: {webview_id:?}");
             return;
         };
         if !webview.set_theme(theme) {

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
 
 use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme, ViewportDetails};
@@ -17,6 +19,7 @@ use servo_constellation_traits::{ScreenshotReadinessResponse, SessionHistoryTrav
 use style_traits::CSSPixel;
 
 use crate::browsingcontext::{BrowsingContext, FullyActiveBrowsingContextsIterator};
+use crate::constellation::BrowsingContextGroup;
 use crate::pipeline::Pipeline;
 use crate::screenshot_readiness_request::{ScreenshotReadinessRequest, ScreenshotRequestState};
 use crate::session_history::{JointSessionHistory, SessionHistoryChange};
@@ -39,6 +42,11 @@ pub(crate) struct ConstellationWebView {
     /// document is active. Between starting the load and it activating,
     /// we store a `SessionHistoryChange` object for the navigation in progress.
     pub pending_changes: Vec<SessionHistoryChange>,
+
+    /// The [`BrowsingContextGroup`] associated with this [`ConstellationWebView`]. Every
+    /// `WebView` has a single [`BrowsingContextGroup`], but that group may be shared amongst
+    /// multiple `WebView`s in the case of `window.open()`.
+    browsing_context_group: Rc<RefCell<BrowsingContextGroup>>,
 
     /// The currently focused browsing context in this webview for key events.
     /// The focused pipeline is the current entry of the focused browsing
@@ -96,6 +104,7 @@ pub(crate) struct ConstellationWebView {
 impl ConstellationWebView {
     pub(crate) fn new(
         webview_id: WebViewId,
+        browsing_context_group: Rc<RefCell<BrowsingContextGroup>>,
         focused_browsing_context_id: BrowsingContextId,
         user_content_manager_id: Option<UserContentManagerId>,
     ) -> Self {
@@ -105,6 +114,7 @@ impl ConstellationWebView {
             active_top_level_pipeline_id: None,
             active_top_level_pipeline_epoch: Epoch::default(),
             pending_changes: Default::default(),
+            browsing_context_group,
             focused_browsing_context_id,
             hovered_browsing_context_id: None,
             last_mouse_move_point: Default::default(),
@@ -116,6 +126,10 @@ impl ConstellationWebView {
             accessibility_active: false,
             screenshot_readiness_requests: Default::default(),
         }
+    }
+
+    pub(crate) fn browsing_context_group(&self) -> Rc<RefCell<BrowsingContextGroup>> {
+        self.browsing_context_group.clone()
     }
 
     /// Set the [`Theme`] on this [`ConstellationWebView`] returning true if the theme changed.

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -338,14 +338,6 @@ namespace_id! {BrowsingContextId, BrowsingContextIndex, "BrowsingContext"}
 size_of_test!(BrowsingContextId, 8);
 size_of_test!(Option<BrowsingContextId>, 8);
 
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub struct BrowsingContextGroupId(pub u32);
-impl fmt::Display for BrowsingContextGroupId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "BrowsingContextGroup{:?}", self)
-    }
-}
-
 impl BrowsingContextId {
     pub fn from_string(str: &str) -> Option<BrowsingContextId> {
         let re = Regex::new(r"^BrowsingContext\((\d+),(\d+)\)$").ok()?;


### PR DESCRIPTION
This is the first simplification from #47294. It moves
`BrowsingContextGroup` to `ConstellationWebView`. Every WebView has a
single `BrowsingContextGroup`, but this group might be shared between
`WebView`s. This is enforced by keeping groups in an `Rc<RefCell<..>>`
-- the shared ownership reflecting the reality of the specification.

In addition, this change fixes a leak of `WebGPU` threads that happened
when a `WebView` was destroyed before shutdown.

Testing: This should not change behavior (other than the leak fix, which
is difficult to test) so is covered by existing tests.
Fixes: This is part of #47294.
