### PR TITLE
crown: Also check for `String::new()` in `manual_domstring_new`

### DIFF
--- a/support/crown/README.md
+++ b/support/crown/README.md
@@ -1,0 +1,10 @@
+# Working on crown
+
+While there are test files, running them won't show print output.
+Write the test and then debug crown by running it manually on those tests:
+
+```
+RUST_BACKTRACE=1 cargo run -- \
+      "-Zcrate-attr=feature(register_tool)" \
+      "-Zcrate-attr=register_tool(crown)" tests/<test-file-here>
+```

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -5,6 +5,7 @@
 use rustc_ast::ast::LitKind;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId};
+use rustc_hir::definitions::DefPathData;
 use rustc_hir::ExprKind;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::{EvaluationResult, Obligation, ObligationCause};
@@ -33,10 +34,11 @@ pub fn match_def_path(cx: &LateContext, def_id: DefId, path: &[Symbol]) -> bool 
         return false;
     }
 
-    other
-        .into_iter()
-        .zip(path)
-        .all(|(e, p)| e.data.get_opt_name().as_ref() == Some(p))
+    other.into_iter().zip(path).all(|(e, p)| {
+        // Impl don't have an operation name, but we still need to match to it
+        (matches!(e.data, DefPathData::Impl) && p.as_str() == "Impl") ||
+            e.data.get_opt_name().as_ref() == Some(p)
+    })
 }
 
 pub fn in_derive_expn(span: Span) -> bool {

--- a/support/crown/src/manual_domstring_new.rs
+++ b/support/crown/src/manual_domstring_new.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use rustc_hir::{self as hir};
+use rustc_hir::{self as hir, ExprKind};
 use rustc_lint::{LateContext, LateLintPass, Lint, LintContext, LintPass, LintStore};
 use rustc_macros::Diagnostic;
 use rustc_middle::ty;
@@ -105,12 +105,26 @@ impl<'tcx> ManualDOMStringPass {
         }
     }
 
+    fn is_new_string_constructor(&self, cx: &LateContext<'tcx>, expr_kind: &ExprKind<'_>) -> bool {
+        let sym = &self.symbols;
+        if let ExprKind::Call(callee, _args) = expr_kind {
+            let ty = cx.typeck_results().expr_ty(callee);
+            let ty::FnDef(fn_, _def_id) = ty.kind() else {
+                return false;
+            };
+            match_def_path(cx, *fn_, &[sym.alloc, sym.string, sym.Impl, sym.new])
+        } else {
+            false
+        }
+    }
+
     fn maybe_report_for_string_value(
+        &mut self,
         cx: &LateContext<'tcx>,
         span: Span,
         expr_kind: &hir::ExprKind<'_>,
     ) {
-        if is_expr_kind_empty_str(expr_kind) {
+        if is_expr_kind_empty_str(expr_kind) || self.is_new_string_constructor(cx, expr_kind) {
             cx.emit_span_lint(
                 MANUAL_DOMSTRING_NEW,
                 span,
@@ -150,7 +164,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualDOMStringPass {
                 if args.len() != 1 {
                     return;
                 }
-                Self::maybe_report_for_string_value(cx, expr.span, &args[0].kind);
+                self.maybe_report_for_string_value(cx, expr.span, &args[0].kind);
             },
             hir::ExprKind::MethodCall(path, callee, _, _) => {
                 let ty = cx.typeck_results().expr_ty(expr);
@@ -162,7 +176,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualDOMStringPass {
                 if path.ident.name != sym.into {
                     return;
                 }
-                Self::maybe_report_for_string_value(cx, expr.span, &callee.kind);
+                self.maybe_report_for_string_value(cx, expr.span, &callee.kind);
             },
             _ => {},
         }
@@ -176,4 +190,8 @@ symbols! {
     From
     from
     into
+    alloc
+    string
+    Impl
+    new
 }

--- a/support/crown/tests/compile-fail/manual_domstring_empty.rs
+++ b/support/crown/tests/compile-fail/manual_domstring_empty.rs
@@ -16,20 +16,28 @@ impl DOMString {
 }
 
 impl From<&str> for DOMString {
-    fn from(string: &str) -> Self {
+    fn from(_string: &str) -> Self {
         Self {}
     }
 }
 
-fn func(str_: DOMString) {}
+impl From<std::string::String> for DOMString {
+    fn from(_string: String) -> Self {
+        Self {}
+    }
+}
+
+fn func(_str: DOMString) {}
 
 fn main() {
-    DOMString::from("");
-    //~^ ERROR: 27:5: 27:24: use DOMString::new() instead [crown::manual_domstring_new]
-    let dom_string: DOMString = "".into();
-    //~^ ERROR: 29:33: 29:42: use DOMString::new() instead [crown::manual_domstring_new]
-    func("".into());
-    //~^ ERROR: 31:10: 31:19: use DOMString::new() instead [crown::manual_domstring_new]
+    let _ = DOMString::from("");
+    //~^ 33:13: 33:32: use DOMString::new() instead [crown::manual_domstring_new]
+    let _ = DOMString::from(String::new());
+    //~^ 35:13: 35:43: use DOMString::new() instead [crown::manual_domstring_new]
+    let _: DOMString = "".into();
+    //~^ ERROR: 37:24: 37:33: use DOMString::new() instead [crown::manual_domstring_new]
+    let _ = func("".into());
+    //~^ 39:18: 39:27: use DOMString::new() instead [crown::manual_domstring_new]
     let t = "";
-    DOMString::from(t);
+    let _ = DOMString::from(t);
 }

--- a/support/crown/tests/run-pass/manual_domstring_empty.rs
+++ b/support/crown/tests/run-pass/manual_domstring_empty.rs
@@ -20,6 +20,12 @@ impl From<&str> for DOMString {
     }
 }
 
+impl From<std::string::String> for DOMString {
+    fn from(_string: String) -> Self {
+        Self {}
+    }
+}
+
 fn func(str_: DOMString) {}
 
 fn func_with_str(str_: &str) {
@@ -29,6 +35,11 @@ fn func_with_str(str_: &str) {
     func(str_.into());
 }
 
+fn func_with_string(string_: String) {
+    DOMString::from(string_);
+}
+
 fn main() {
     func_with_str("");
+    func_with_string(String::new())
 }


### PR DESCRIPTION
While we are also turning on `manual_string_new` as a rustc linter check, I realised that `DomString::from(String::new())` is also redundant. Also added a README to make it more obvious how to manually run crown on tests files to have print output.

Part of #47512

Testing: it compiles with Crown and Crown tests pass