### PR TITLE
script: Focus text control elements on `select()`

### DIFF
--- a/components/script/dom/html/form_controls/htmlinputelement.rs
+++ b/components/script/dom/html/form_controls/htmlinputelement.rs
@@ -1464,8 +1464,8 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-select>
-    fn Select(&self) {
-        self.selection().dom_select();
+    fn Select(&self, cx: &mut JSContext) {
+        self.selection().dom_select(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>

--- a/components/script/dom/html/form_controls/htmltextareaelement.rs
+++ b/components/script/dom/html/form_controls/htmltextareaelement.rs
@@ -449,8 +449,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     make_labels_getter!(Labels, labels_node_list);
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-select>
-    fn Select(&self) {
-        self.selection().dom_select();
+    fn Select(&self, cx: &mut JSContext) {
+        self.selection().dom_select(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>

--- a/components/script/dom/html/form_controls/text_control.rs
+++ b/components/script/dom/html/form_controls/text_control.rs
@@ -9,6 +9,7 @@
 
 use std::cell::Ref;
 
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use servo_base::text::Utf16CodeUnits;
 
@@ -21,6 +22,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::form_controls::text_input::{
     EmbedderClipboardProvider, SelectionDirection, SelectionState, TextInput,
 };
+use crate::dom::node::focus::FocusTrigger;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::types::Element;
 
@@ -54,12 +56,18 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-select>
-    pub(crate) fn dom_select(&self) {
+    pub(crate) fn dom_select(&self, cx: &mut JSContext) {
         // Step 1: If this element is an input element, and either select() does not apply
         // to this element or the corresponding control has no selectable text, return.
         if !self.element.has_selectable_text() {
             return;
         }
+
+        // Focus the element. This matches the behavior of other browsers. Note that _only_
+        // `select()` causes focus, not setting selectionStart or selectionEnd.
+        self.element
+            .upcast::<Node>()
+            .run_the_focusing_steps(cx, None, FocusTrigger::Other);
 
         // Step 2 : Set the selection range with 0 and infinity.
         self.set_range(

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -738,6 +738,7 @@ DOMInterfaces = {
         'GetLabels',
         'GetValueAsDate',
         'ReportValidity',
+        'Select',
         'SetCustomValidity',
         'StepDown',
         'StepUp',
@@ -833,7 +834,7 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
+    'cx': ['CheckValidity', 'ReportValidity', 'Select', 'SetCustomValidity', 'Validity', 'ValidationMessage', 'Labels'],
 },
 
 'HTMLVideoElement': {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14534,6 +14534,13 @@
       {}
      ]
     ],
+    "input-select-focus.html": [
+     "d65ba8c70f4ced9c2d3f4a303fdb448d8b9fbd8e",
+     [
+      null,
+      {}
+     ]
+    ],
     "input-value.html": [
      "a2a12d44d0331164651816710eeb2ddcb1738735",
      [
@@ -15136,6 +15143,13 @@
         ]
        ]
       }
+     ]
+    ],
+    "textarea-select-focus.html": [
+     "237aec19f09a727678f2715a83c35943a4789afd",
+     [
+      null,
+      {}
      ]
     ],
     "textcontent.html": [

--- a/tests/wpt/mozilla/tests/mozilla/input-select-focus.html
+++ b/tests/wpt/mozilla/tests/mozilla/input-select-focus.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>input select should set focus</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input value="Hello" />
+
+<script>
+test(() => {
+  const el = document.querySelector("input");
+  assert_not_equals(document.activeElement, el);
+  el.select();
+  assert_equals(document.activeElement, el);
+});
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/textarea-select-focus.html
+++ b/tests/wpt/mozilla/tests/mozilla/textarea-select-focus.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>textarea select should set focus</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<textarea>Hello</textarea>
+
+<script>
+test(() => {
+  const el = document.querySelector("textarea");
+  assert_not_equals(document.activeElement, el);
+  el.select();
+  assert_equals(document.activeElement, el);
+});
+</script>


### PR DESCRIPTION
This matches the behavior of other browsers.

Note: took a stab at fixing this issue after the previous PR (#47826) was closed, as I thought it would be a good way to learn a little bit about the Servo codebase! Only thing I was unsure about was where to put the tests (ended up putting them in tests/wpt/mozilla/tests/mozilla), and if the style of testing was okay for this specific problem (using the `assert_*` from the JS test harness as opposed to reference testing, thought it would be much easier to do the former).

Testing: New WPT tests validating active element via the DOM API.
Fixes: #47753
