### PR TITLE
media: implement `MediaDevices.ondevicechange` with gstreamer backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8916,6 +8916,7 @@ name = "servo-media-streams"
 version = "0.6.0"
 dependencies = [
  "malloc_size_of_derive",
+ "servo-base",
  "servo-malloc-size-of",
  "uuid",
 ]

--- a/components/media/backends/dummy/lib.rs
+++ b/components/media/backends/dummy/lib.rs
@@ -397,4 +397,6 @@ impl MediaDeviceMonitor for DummyMediaDeviceMonitor {
     fn enumerate_devices(&self) -> Option<Vec<MediaDeviceInfo>> {
         Some(vec![])
     }
+
+    fn set_devicechange_callback(&self, _callback: Option<GenericCallback<()>>) {}
 }

--- a/components/media/backends/dummy/lib.rs
+++ b/components/media/backends/dummy/lib.rs
@@ -398,5 +398,5 @@ impl MediaDeviceMonitor for DummyMediaDeviceMonitor {
         Some(vec![])
     }
 
-    fn set_devicechange_callback(&self, _callback: Option<GenericCallback<()>>) {}
+    fn add_devicechange_callback(&self, _callback: GenericCallback<()>) {}
 }

--- a/components/media/backends/dummy/lib.rs
+++ b/components/media/backends/dummy/lib.rs
@@ -117,8 +117,8 @@ impl Backend for DummyBackend {
         SupportsMediaType::No
     }
 
-    fn get_device_monitor(&self) -> Box<dyn MediaDeviceMonitor> {
-        Box::new(DummyMediaDeviceMonitor {})
+    fn get_device_monitor(&self) -> Arc<dyn MediaDeviceMonitor> {
+        Arc::new(DummyMediaDeviceMonitor {})
     }
 }
 

--- a/components/media/backends/gstreamer/device_monitor.rs
+++ b/components/media/backends/gstreamer/device_monitor.rs
@@ -9,28 +9,34 @@ use gstreamer::prelude::*;
 use servo_base::generic_channel::GenericCallback;
 use servo_media_streams::device_monitor::{MediaDeviceInfo, MediaDeviceKind, MediaDeviceMonitor};
 
+const AUDIO_SOURCE: &str = "Audio/Source";
+const AUDIO_SINK: &str = "Audio/Sink";
+const VIDEO_SOURCE: &str = "Video/Source";
+
 pub struct GStreamerDeviceMonitor {
+    device_monitor: GstDeviceMonitor,
     devices: RefCell<Option<Vec<MediaDeviceInfo>>>,
 }
 
 impl GStreamerDeviceMonitor {
     pub fn new() -> Self {
-        Self {
-            devices: RefCell::new(None),
-        }
-    }
-
-    fn get_devices(&self) -> Result<Vec<MediaDeviceInfo>, ()> {
-        const AUDIO_SOURCE: &str = "Audio/Source";
-        const AUDIO_SINK: &str = "Audio/Sink";
-        const VIDEO_SOURCE: &str = "Video/Source";
         let device_monitor = GstDeviceMonitor::new();
+
         let audio_caps = gstreamer_audio::AudioCapsBuilder::new().build();
         device_monitor.add_filter(Some(AUDIO_SOURCE), Some(&audio_caps));
         device_monitor.add_filter(Some(AUDIO_SINK), Some(&audio_caps));
         let video_caps = gstreamer_video::VideoCapsBuilder::new().build();
         device_monitor.add_filter(Some(VIDEO_SOURCE), Some(&video_caps));
-        let devices = device_monitor
+
+        Self {
+            device_monitor: GstDeviceMonitor::new(),
+            devices: RefCell::new(None),
+        }
+    }
+
+    fn get_devices(&self) -> Result<Vec<MediaDeviceInfo>, ()> {
+        let devices = self
+            .device_monitor
             .devices()
             .iter()
             .filter_map(|device| {

--- a/components/media/backends/gstreamer/device_monitor.rs
+++ b/components/media/backends/gstreamer/device_monitor.rs
@@ -5,7 +5,7 @@
 use std::cell::RefCell;
 
 use gstreamer::{
-    Bus as GstBus, DeviceMonitor as GstDeviceMonitor, MessageView,
+    DeviceMonitor as GstDeviceMonitor, MessageView,
     bus::BusWatchGuard as GstBusWatchGuard, prelude::*,
 };
 use servo_base::generic_channel::GenericCallback;

--- a/components/media/backends/gstreamer/device_monitor.rs
+++ b/components/media/backends/gstreamer/device_monitor.rs
@@ -4,10 +4,8 @@
 
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
-use gstreamer::{
-    DeviceMonitor as GstDeviceMonitor, MessageView, bus::BusWatchGuard as GstBusWatchGuard,
-    prelude::*,
-};
+use gstreamer::prelude::*;
+use gstreamer::{BusSyncReply, DeviceMonitor as GstDeviceMonitor, MessageView};
 use servo_base::generic_channel::GenericCallback;
 use servo_media_streams::device_monitor::{MediaDeviceInfo, MediaDeviceKind, MediaDeviceMonitor};
 
@@ -19,7 +17,6 @@ static INSTANCE: OnceLock<Arc<GStreamerDeviceMonitor>> = OnceLock::new();
 
 pub struct GStreamerDeviceMonitor {
     monitor: GstDeviceMonitor,
-    _watch_guard: GstBusWatchGuard,
     devices: Arc<RwLock<Option<Vec<MediaDeviceInfo>>>>,
     callbacks: Arc<Mutex<Vec<GenericCallback<()>>>>,
 }
@@ -42,34 +39,31 @@ impl GStreamerDeviceMonitor {
         monitor.add_filter(Some(VIDEO_SOURCE), Some(&video_caps));
 
         // watch changes
-        let watch_guard = monitor
-            .bus()
-            .add_watch({
-                let devices = devices.clone();
-                let callbacks = callbacks.clone();
-                move |_, msg| {
-                    if let MessageView::DeviceAdded(_)
-                    | MessageView::DeviceRemoved(_)
-                    | MessageView::DeviceChanged(_) = msg.view()
-                    {
-                        // evict cache
-                        *devices.write().unwrap() = None;
+        monitor.bus().set_sync_handler({
+            let devices = devices.clone();
+            let callbacks = callbacks.clone();
+            move |_, msg| {
+                if let MessageView::DeviceAdded(_) |
+                MessageView::DeviceRemoved(_) |
+                MessageView::DeviceChanged(_) = msg.view()
+                {
+                    // TODO: should check whether DeviceChanged is about default device
+                    // evict cache
+                    *devices.write().unwrap() = None;
 
-                        for callback in callbacks.lock().unwrap().iter() {
-                            _ = callback.send(());
-                        }
+                    for callback in callbacks.lock().unwrap().iter() {
+                        _ = callback.send(());
                     }
-                    glib::ControlFlow::Continue
                 }
-            })
-            .expect("Failed to add watcher");
+                BusSyncReply::Pass
+            }
+        });
 
         // start monitor
         monitor.start().expect("Failed to start monitor");
 
         Self {
             monitor,
-            _watch_guard: watch_guard,
             devices,
             callbacks,
         }

--- a/components/media/backends/gstreamer/device_monitor.rs
+++ b/components/media/backends/gstreamer/device_monitor.rs
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::{
-    sync::{Arc, Mutex, OnceLock, RwLock},
-};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use gstreamer::{
     DeviceMonitor as GstDeviceMonitor, MessageView, bus::BusWatchGuard as GstBusWatchGuard,
@@ -21,8 +19,9 @@ static INSTANCE: OnceLock<Arc<GStreamerDeviceMonitor>> = OnceLock::new();
 
 pub struct GStreamerDeviceMonitor {
     monitor: GstDeviceMonitor,
-    watch_guard: Mutex<Option<GstBusWatchGuard>>,
-    devices: RwLock<Option<Vec<MediaDeviceInfo>>>,
+    _watch_guard: GstBusWatchGuard,
+    devices: Arc<RwLock<Option<Vec<MediaDeviceInfo>>>>,
+    callbacks: Arc<Mutex<Vec<GenericCallback<()>>>>,
 }
 
 impl GStreamerDeviceMonitor {
@@ -32,6 +31,8 @@ impl GStreamerDeviceMonitor {
 
     pub fn new() -> Self {
         let monitor = GstDeviceMonitor::new();
+        let devices = Arc::new(RwLock::new(None));
+        let callbacks = Arc::new(Mutex::new(Vec::<GenericCallback<()>>::new()));
 
         // add filters
         let audio_caps = gstreamer_audio::AudioCapsBuilder::new().build();
@@ -40,13 +41,37 @@ impl GStreamerDeviceMonitor {
         let video_caps = gstreamer_video::VideoCapsBuilder::new().build();
         monitor.add_filter(Some(VIDEO_SOURCE), Some(&video_caps));
 
+        // watch changes
+        let watch_guard = monitor
+            .bus()
+            .add_watch({
+                let devices = devices.clone();
+                let callbacks = callbacks.clone();
+                move |_, msg| {
+                    if let MessageView::DeviceAdded(_)
+                    | MessageView::DeviceRemoved(_)
+                    | MessageView::DeviceChanged(_) = msg.view()
+                    {
+                        // evict cache
+                        *devices.write().unwrap() = None;
+
+                        for callback in callbacks.lock().unwrap().iter() {
+                            _ = callback.send(());
+                        }
+                    }
+                    glib::ControlFlow::Continue
+                }
+            })
+            .expect("Failed to add watcher");
+
         // start monitor
         monitor.start().expect("Failed to start monitor");
 
         Self {
             monitor,
-            watch_guard: Default::default(),
-            devices: RwLock::new(None),
+            _watch_guard: watch_guard,
+            devices,
+            callbacks,
         }
     }
 
@@ -91,22 +116,7 @@ impl MediaDeviceMonitor for GStreamerDeviceMonitor {
         Some(devices)
     }
 
-    fn set_devicechange_callback(&self, callback: Option<GenericCallback<()>>) {
-        // old watch automatically cleanup when old guard drops
-        *self.watch_guard.lock().unwrap() = callback.map(|callback| {
-            self.monitor
-                .bus()
-                .add_watch(move |_, msg| {
-                    if let MessageView::DeviceAdded(_)
-                    | MessageView::DeviceRemoved(_)
-                    | MessageView::DeviceChanged(_) = msg.view()
-                    {
-                        // TODO: update to new events
-                        _ = callback.send(());
-                    }
-                    glib::ControlFlow::Continue
-                })
-                .expect("Failed to add watcher")
-        });
+    fn add_devicechange_callback(&self, callback: GenericCallback<()>) {
+        self.callbacks.lock().unwrap().push(callback);
     }
 }

--- a/components/media/backends/gstreamer/device_monitor.rs
+++ b/components/media/backends/gstreamer/device_monitor.rs
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::{
+    sync::{Arc, Mutex, OnceLock, RwLock},
+};
 
 use gstreamer::{
-    DeviceMonitor as GstDeviceMonitor, MessageView,
-    bus::BusWatchGuard as GstBusWatchGuard, prelude::*,
+    DeviceMonitor as GstDeviceMonitor, MessageView, bus::BusWatchGuard as GstBusWatchGuard,
+    prelude::*,
 };
 use servo_base::generic_channel::GenericCallback;
 use servo_media_streams::device_monitor::{MediaDeviceInfo, MediaDeviceKind, MediaDeviceMonitor};
@@ -15,13 +17,19 @@ const AUDIO_SOURCE: &str = "Audio/Source";
 const AUDIO_SINK: &str = "Audio/Sink";
 const VIDEO_SOURCE: &str = "Video/Source";
 
+static INSTANCE: OnceLock<Arc<GStreamerDeviceMonitor>> = OnceLock::new();
+
 pub struct GStreamerDeviceMonitor {
     monitor: GstDeviceMonitor,
-    watch_guard: RefCell<Option<GstBusWatchGuard>>,
-    devices: RefCell<Option<Vec<MediaDeviceInfo>>>,
+    watch_guard: Mutex<Option<GstBusWatchGuard>>,
+    devices: RwLock<Option<Vec<MediaDeviceInfo>>>,
 }
 
 impl GStreamerDeviceMonitor {
+    pub fn get() -> Arc<Self> {
+        INSTANCE.get_or_init(|| Arc::new(Self::new())).clone()
+    }
+
     pub fn new() -> Self {
         let monitor = GstDeviceMonitor::new();
 
@@ -38,7 +46,7 @@ impl GStreamerDeviceMonitor {
         Self {
             monitor,
             watch_guard: Default::default(),
-            devices: RefCell::new(None),
+            devices: RwLock::new(None),
         }
     }
 
@@ -74,18 +82,18 @@ impl Drop for GStreamerDeviceMonitor {
 impl MediaDeviceMonitor for GStreamerDeviceMonitor {
     fn enumerate_devices(&self) -> Option<Vec<MediaDeviceInfo>> {
         {
-            if let Some(ref devices) = *self.devices.borrow() {
+            if let Some(ref devices) = *self.devices.read().unwrap() {
                 return Some(devices.clone());
             }
         }
         let devices = self.get_devices().ok()?;
-        *self.devices.borrow_mut() = Some(devices.clone());
+        *self.devices.write().unwrap() = Some(devices.clone());
         Some(devices)
     }
 
     fn set_devicechange_callback(&self, callback: Option<GenericCallback<()>>) {
         // old watch automatically cleanup when old guard drops
-        *self.watch_guard.borrow_mut() = callback.map(|callback| {
+        *self.watch_guard.lock().unwrap() = callback.map(|callback| {
             self.monitor
                 .bus()
                 .add_watch(move |_, msg| {
@@ -93,6 +101,7 @@ impl MediaDeviceMonitor for GStreamerDeviceMonitor {
                     | MessageView::DeviceRemoved(_)
                     | MessageView::DeviceChanged(_) = msg.view()
                     {
+                        // TODO: update to new events
                         _ = callback.send(());
                     }
                     glib::ControlFlow::Continue

--- a/components/media/backends/gstreamer/device_monitor.rs
+++ b/components/media/backends/gstreamer/device_monitor.rs
@@ -4,8 +4,10 @@
 
 use std::cell::RefCell;
 
-use gstreamer::DeviceMonitor as GstDeviceMonitor;
-use gstreamer::prelude::*;
+use gstreamer::{
+    Bus as GstBus, DeviceMonitor as GstDeviceMonitor, MessageView,
+    bus::BusWatchGuard as GstBusWatchGuard, prelude::*,
+};
 use servo_base::generic_channel::GenericCallback;
 use servo_media_streams::device_monitor::{MediaDeviceInfo, MediaDeviceKind, MediaDeviceMonitor};
 
@@ -14,29 +16,35 @@ const AUDIO_SINK: &str = "Audio/Sink";
 const VIDEO_SOURCE: &str = "Video/Source";
 
 pub struct GStreamerDeviceMonitor {
-    device_monitor: GstDeviceMonitor,
+    monitor: GstDeviceMonitor,
+    watch_guard: RefCell<Option<GstBusWatchGuard>>,
     devices: RefCell<Option<Vec<MediaDeviceInfo>>>,
 }
 
 impl GStreamerDeviceMonitor {
     pub fn new() -> Self {
-        let device_monitor = GstDeviceMonitor::new();
+        let monitor = GstDeviceMonitor::new();
 
+        // add filters
         let audio_caps = gstreamer_audio::AudioCapsBuilder::new().build();
-        device_monitor.add_filter(Some(AUDIO_SOURCE), Some(&audio_caps));
-        device_monitor.add_filter(Some(AUDIO_SINK), Some(&audio_caps));
+        monitor.add_filter(Some(AUDIO_SOURCE), Some(&audio_caps));
+        monitor.add_filter(Some(AUDIO_SINK), Some(&audio_caps));
         let video_caps = gstreamer_video::VideoCapsBuilder::new().build();
-        device_monitor.add_filter(Some(VIDEO_SOURCE), Some(&video_caps));
+        monitor.add_filter(Some(VIDEO_SOURCE), Some(&video_caps));
+
+        // start monitor
+        monitor.start().expect("Failed to start monitor");
 
         Self {
-            device_monitor: GstDeviceMonitor::new(),
+            monitor,
+            watch_guard: Default::default(),
             devices: RefCell::new(None),
         }
     }
 
     fn get_devices(&self) -> Result<Vec<MediaDeviceInfo>, ()> {
         let devices = self
-            .device_monitor
+            .monitor
             .devices()
             .iter()
             .filter_map(|device| {
@@ -57,6 +65,12 @@ impl GStreamerDeviceMonitor {
     }
 }
 
+impl Drop for GStreamerDeviceMonitor {
+    fn drop(&mut self) {
+        self.monitor.stop();
+    }
+}
+
 impl MediaDeviceMonitor for GStreamerDeviceMonitor {
     fn enumerate_devices(&self) -> Option<Vec<MediaDeviceInfo>> {
         {
@@ -70,6 +84,20 @@ impl MediaDeviceMonitor for GStreamerDeviceMonitor {
     }
 
     fn set_devicechange_callback(&self, callback: Option<GenericCallback<()>>) {
-        // TODO:
+        // old watch automatically cleanup when old guard drops
+        *self.watch_guard.borrow_mut() = callback.map(|callback| {
+            self.monitor
+                .bus()
+                .add_watch(move |_, msg| {
+                    if let MessageView::DeviceAdded(_)
+                    | MessageView::DeviceRemoved(_)
+                    | MessageView::DeviceChanged(_) = msg.view()
+                    {
+                        _ = callback.send(());
+                    }
+                    glib::ControlFlow::Continue
+                })
+                .expect("Failed to add watcher")
+        });
     }
 }

--- a/components/media/backends/gstreamer/device_monitor.rs
+++ b/components/media/backends/gstreamer/device_monitor.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 
 use gstreamer::DeviceMonitor as GstDeviceMonitor;
 use gstreamer::prelude::*;
+use servo_base::generic_channel::GenericCallback;
 use servo_media_streams::device_monitor::{MediaDeviceInfo, MediaDeviceKind, MediaDeviceMonitor};
 
 pub struct GStreamerDeviceMonitor {
@@ -60,5 +61,9 @@ impl MediaDeviceMonitor for GStreamerDeviceMonitor {
         let devices = self.get_devices().ok()?;
         *self.devices.borrow_mut() = Some(devices.clone());
         Some(devices)
+    }
+
+    fn set_devicechange_callback(&self, callback: Option<GenericCallback<()>>) {
+        // TODO:
     }
 }

--- a/components/media/backends/gstreamer/lib.rs
+++ b/components/media/backends/gstreamer/lib.rs
@@ -323,8 +323,8 @@ impl Backend for GStreamerBackend {
         self.media_instance_action(id, &|instance: &dyn MediaInstance| instance.resume());
     }
 
-    fn get_device_monitor(&self) -> Box<dyn MediaDeviceMonitor> {
-        Box::new(GStreamerDeviceMonitor::new())
+    fn get_device_monitor(&self) -> Arc<dyn MediaDeviceMonitor> {
+        GStreamerDeviceMonitor::get()
     }
 }
 

--- a/components/media/backends/ohos/lib.rs
+++ b/components/media/backends/ohos/lib.rs
@@ -229,9 +229,9 @@ impl Backend for OhosBackend {
 
     fn get_device_monitor(
         &self,
-    ) -> Box<dyn servo_media_streams::device_monitor::MediaDeviceMonitor> {
+    ) -> Arc<dyn servo_media_streams::device_monitor::MediaDeviceMonitor> {
         warn!("OhosBackend: get_device_monitor not supported");
-        Box::new(OhosDeviceMonitor)
+        Arc::new(OhosDeviceMonitor)
     }
 
     fn mute(&self, id: &ClientContextId, val: bool) {

--- a/components/media/backends/ohos/lib.rs
+++ b/components/media/backends/ohos/lib.rs
@@ -276,5 +276,5 @@ impl MediaDeviceMonitor for OhosDeviceMonitor {
         Some(vec![])
     }
 
-    fn set_devicechange_callback(&self, _callback: Option<GenericCallback<()>>) {}
+    fn add_devicechange_callback(&self, _callback: GenericCallback<()>) {}
 }

--- a/components/media/backends/ohos/lib.rs
+++ b/components/media/backends/ohos/lib.rs
@@ -275,4 +275,6 @@ impl MediaDeviceMonitor for OhosDeviceMonitor {
     fn enumerate_devices(&self) -> Option<Vec<MediaDeviceInfo>> {
         Some(vec![])
     }
+
+    fn set_devicechange_callback(&self, _callback: Option<GenericCallback<()>>) {}
 }

--- a/components/media/servo-media/lib.rs
+++ b/components/media/servo-media/lib.rs
@@ -85,7 +85,7 @@ pub trait Backend: Send + Sync {
     /// The client context identifier is currently an abstraction of Servo's PipelineId.
     fn resume(&self, _id: &ClientContextId) {}
 
-    fn get_device_monitor(&self) -> Box<dyn MediaDeviceMonitor>;
+    fn get_device_monitor(&self) -> Arc<dyn MediaDeviceMonitor>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/components/media/streams/Cargo.toml
+++ b/components/media/streams/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [dependencies]
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
+servo-base = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [lints]

--- a/components/media/streams/device_monitor.rs
+++ b/components/media/streams/device_monitor.rs
@@ -20,5 +20,6 @@ pub struct MediaDeviceInfo {
 
 pub trait MediaDeviceMonitor {
     fn enumerate_devices(&self) -> Option<Vec<MediaDeviceInfo>>;
-    fn set_devicechange_callback(&self, callback: Option<GenericCallback<()>>);
+    // TODO: find a way to index and remove callback
+    fn add_devicechange_callback(&self, callback: GenericCallback<()>);
 }

--- a/components/media/streams/device_monitor.rs
+++ b/components/media/streams/device_monitor.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use servo_base::generic_channel::GenericCallback;
+
 #[derive(Clone, Copy, Debug)]
 pub enum MediaDeviceKind {
     AudioInput,
@@ -18,4 +20,5 @@ pub struct MediaDeviceInfo {
 
 pub trait MediaDeviceMonitor {
     fn enumerate_devices(&self) -> Option<Vec<MediaDeviceInfo>>;
+    fn set_devicechange_callback(&self, callback: Option<GenericCallback<()>>);
 }

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -7,6 +7,8 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
+use script_bindings::codegen::GenericBindings::EventHandlerBinding::EventHandlerNonNull;
+use script_bindings::inheritance::Castable;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_media::ServoMedia;
 use servo_media::streams::MediaStreamType;
@@ -56,14 +58,14 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
         let p = Promise::new_in_realm(cx);
         let media = ServoMedia::get();
         let stream = MediaStream::new(cx, &self.global());
-        if let Some(constraints) = convert_constraints(&constraints.audio) &&
-            let Some(audio) = media.create_audioinput_stream(constraints)
+        if let Some(constraints) = convert_constraints(&constraints.audio)
+            && let Some(audio) = media.create_audioinput_stream(constraints)
         {
             let track = MediaStreamTrack::new(cx, &self.global(), audio, MediaStreamType::Audio);
             stream.add_track(&track);
         }
-        if let Some(constraints) = convert_constraints(&constraints.video) &&
-            let Some(video) = media.create_videoinput_stream(constraints)
+        if let Some(constraints) = convert_constraints(&constraints.video)
+            && let Some(video) = media.create_videoinput_stream(constraints)
         {
             let track = MediaStreamTrack::new(cx, &self.global(), video, MediaStreamType::Video);
             stream.add_track(&track);
@@ -110,6 +112,23 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
 
         // Step 3.
         p
+    }
+
+    fn GetOndevicechange(
+        &self,
+        cx: &mut JSContext,
+    ) -> Option<Rc<EventHandlerNonNull<crate::DomTypeHolder>>> {
+        self.upcast::<EventTarget>()
+            .get_event_handler_common(cx, "devicechange")
+    }
+
+    fn SetOndevicechange(
+        &self,
+        cx: &mut JSContext,
+        listener: Option<Rc<EventHandlerNonNull<crate::DomTypeHolder>>>,
+    ) {
+        self.upcast::<EventTarget>()
+            .set_event_handler_common(cx, "devicechange", listener)
     }
 }
 

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -62,7 +62,7 @@ impl MediaDevices {
         .unwrap();
         ServoMedia::get()
             .get_device_monitor()
-            .set_devicechange_callback(Some(callback));
+            .add_devicechange_callback(callback);
 
         this
     }

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -40,9 +40,13 @@ pub(crate) struct MediaDevices {
 
 impl MediaDevices {
     pub(crate) fn new_inherited() -> MediaDevices {
-        let this = MediaDevices {
+        MediaDevices {
             eventtarget: EventTarget::new_inherited(),
-        };
+        }
+    }
+
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<MediaDevices> {
+        let this = reflect_dom_object_with_cx(Box::new(MediaDevices::new_inherited()), global, cx);
 
         let task_source = this
             .global()
@@ -50,7 +54,7 @@ impl MediaDevices {
             .user_interaction_task_source()
             .to_sendable();
         let callback = GenericCallback::new({
-            let this = Trusted::new(&this);
+            let this: Trusted<MediaDevices> = Trusted::new(&this);
             move |_| {
                 let this = this.clone();
                 task_source.queue(task!(fire_devicechange: move |cx| {
@@ -66,10 +70,6 @@ impl MediaDevices {
 
         this
     }
-
-    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<MediaDevices> {
-        reflect_dom_object_with_cx(Box::new(MediaDevices::new_inherited()), global, cx)
-    }
 }
 
 impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
@@ -82,14 +82,14 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
         let p = Promise::new_in_realm(cx);
         let media = ServoMedia::get();
         let stream = MediaStream::new(cx, &self.global());
-        if let Some(constraints) = convert_constraints(&constraints.audio)
-            && let Some(audio) = media.create_audioinput_stream(constraints)
+        if let Some(constraints) = convert_constraints(&constraints.audio) &&
+            let Some(audio) = media.create_audioinput_stream(constraints)
         {
             let track = MediaStreamTrack::new(cx, &self.global(), audio, MediaStreamType::Audio);
             stream.add_track(&track);
         }
-        if let Some(constraints) = convert_constraints(&constraints.video)
-            && let Some(video) = media.create_videoinput_stream(constraints)
+        if let Some(constraints) = convert_constraints(&constraints.video) &&
+            let Some(video) = media.create_videoinput_stream(constraints)
         {
             let track = MediaStreamTrack::new(cx, &self.global(), video, MediaStreamType::Video);
             stream.add_track(&track);

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -9,7 +9,9 @@ use js::context::JSContext;
 use js::realm::CurrentRealm;
 use script_bindings::codegen::GenericBindings::EventHandlerBinding::EventHandlerNonNull;
 use script_bindings::inheritance::Castable;
+use script_bindings::refcounted::Trusted;
 use script_bindings::reflector::reflect_dom_object_with_cx;
+use servo_base::generic_channel::GenericCallback;
 use servo_media::ServoMedia;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::capture::{Constrain, ConstrainRange, MediaTrackConstraintSet};
@@ -38,9 +40,31 @@ pub(crate) struct MediaDevices {
 
 impl MediaDevices {
     pub(crate) fn new_inherited() -> MediaDevices {
-        MediaDevices {
+        let this = MediaDevices {
             eventtarget: EventTarget::new_inherited(),
-        }
+        };
+
+        let task_source = this
+            .global()
+            .task_manager()
+            .user_interaction_task_source()
+            .to_sendable();
+        let callback = GenericCallback::new({
+            let this = Trusted::new(&this);
+            move |_| {
+                let this = this.clone();
+                task_source.queue(task!(fire_devicechange: move |cx| {
+                    let this = this.root();
+                    this.upcast::<EventTarget>().fire_event(cx, "devicechange".into());
+                }));
+            }
+        })
+        .unwrap();
+        ServoMedia::get()
+            .get_device_monitor()
+            .set_devicechange_callback(Some(callback));
+
+        this
     }
 
     pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<MediaDevices> {

--- a/components/script_bindings/webidls/MediaDevices.webidl
+++ b/components/script_bindings/webidls/MediaDevices.webidl
@@ -7,7 +7,7 @@
 [Exposed=Window,
 SecureContext, Pref="dom_webrtc_enabled"]
 interface MediaDevices : EventTarget {
-    //                attribute EventHandler ondevicechange;
+    attribute EventHandler ondevicechange;
     Promise<sequence<MediaDeviceInfo>> enumerateDevices();
 };
 


### PR DESCRIPTION
Implement `MediaDevices.ondevicechange`, with gstreamer backend.

Testing: `ondevicechange` is not included in wpt test, and since media is not in any delegate, we cannot test-unit either.
Fixes: https://github.com/servo/servo/issues/43399