### PR TITLE
servo: Wait for the WebRender scene before injecting input in a11y tests

### DIFF
--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -903,6 +903,9 @@ fn test_accessibility_build_initial_tree_after_scroll() {
     let load_webview = webview.clone();
     servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
 
+    // A scroll injected before the scene is built is silently dropped, and the
+    // tree asserted below would be the one built without it.
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
     webview.notify_scroll_event(
         Scroll::Delta(WebViewVector::Device(DeviceVector2D::new(20.0, 40.0))),
         WebViewPoint::Device(DevicePoint::new(250.0, 250.0)),
@@ -1061,6 +1064,11 @@ fn build_webview_and_tree(
 
     let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
     let tree = build_tree(updates);
+
+    // Neither load status nor accessibility updates imply a built WebRender
+    // scene, and callers inject input as soon as this returns.
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
     (servo_test, delegate, webview, tree)
 }
 


### PR DESCRIPTION
This waits for the `WebRender` scene to be built before injecting input in the accessibility tests. The accessibility tests inject input as soon as the load completes, but this does not imply that the scene has been built. A scroll that arrives before the scene is built is hit-tested against the old scene and silently dropped, leaving one test asserting bounds that were never scrolled and another waiting for an update that never comes.

Testing: This changes existing tests. Before this change, 9 of 30 runs failed; after this change, none of 30.
Fixes: #47911