### PR TITLE
script: don't over-allocate attributes

### DIFF
--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -267,6 +267,8 @@ impl Element {
         target_element: &Element,
     ) {
         // Step 2.5. For each attribute of node’s attribute list:
+        let attribute_count = self.attrs().borrow().len();
+        target_element.attrs().reserve_exact(attribute_count);
         for attr in self.attrs().borrow().iter() {
             // Step 2.5.1. Let copyAttribute be the result of cloning a single node given attribute, document, and null.
             let new_value = self.compute_attribute_value_with_style_fast_path(attr);

--- a/components/script/dom/element/attributes/storage.rs
+++ b/components/script/dom/element/attributes/storage.rs
@@ -278,6 +278,11 @@ impl AttributeStorage {
         unsafe { self.0.borrow_for_layout() }
     }
 
+    /// Reserve room for exactly `additional` more attributes.
+    pub(crate) fn reserve_exact(&self, additional: usize) {
+        self.0.borrow_mut().reserve_exact(additional);
+    }
+
     /// Push raw attribute data.
     pub(crate) fn push_raw(&self, data: ContentAttributeData) {
         self.0.borrow_mut().push(AttributeEntry::Raw(data));

--- a/components/script/dom/element/attributes/storage.rs
+++ b/components/script/dom/element/attributes/storage.rs
@@ -278,7 +278,8 @@ impl AttributeStorage {
         unsafe { self.0.borrow_for_layout() }
     }
 
-    /// Reserve room for exactly `additional` more attributes.
+    /// Reserve room for at least `additional` more attributes.
+    #[inline]
     pub(crate) fn reserve_exact(&self, additional: usize) {
         self.0.borrow_mut().reserve_exact(additional);
     }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -2203,6 +2203,7 @@ fn create_element_for_token(
     let element = Element::create(cx, name, is, document, creator, creation_mode, None);
 
     // Step 11. Append each attribute in the given token to element.
+    element.attrs().reserve_exact(attrs.len());
     for attr in attrs {
         element.set_attribute_from_parser(cx, attr.name, attr.value);
     }


### PR DESCRIPTION
By default, an empty Vec gets 4 slots created at first push. This is wasteful when we can be reasonably sure that we won't need that many entries. This patch does it for attributes, when we parse a document or when calling cloneNode.

Testing showed a 230KB memory saving on wikipedia English main page.

Testing: no behavior change. Use about:memory to check memory savings.
