### PR TITLE
servoshell (MacOS): Add CJK fonts for egui

### DIFF
--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -3,9 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos"
+))]
 use std::fs;
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos"
+))]
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -18,12 +28,22 @@ use egui::{
     Button, FontDefinitions, Id, Key, Label, LayerId, Modifiers, Order, PaintCallback, Panel, Vec2,
     WidgetInfo, WidgetType, pos2,
 };
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos"
+))]
 use egui::{FontData, FontFamily};
 use egui_glow::{CallbackFn, EguiGlow};
 use egui_winit::EventResponse;
 use euclid::{Length, Point2D, Rect, Scale, Size2D};
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos"
+))]
 use log::info;
 use log::warn;
 use servo::{
@@ -83,7 +103,12 @@ fn truncate_with_ellipsis(input: &str, max_length: usize) -> String {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "macos"
+))]
 fn load_cjk_fonts(font_candidates: &[(&str, &str)]) -> FontDefinitions {
     let mut fonts = FontDefinitions::default();
     let mut loaded_font_names = Vec::new();
@@ -171,9 +196,13 @@ fn configure_fonts() -> FontDefinitions {
 
 #[cfg(target_os = "macos")]
 fn configure_fonts() -> FontDefinitions {
-    // TODO: Default proportional fonts: ["Ubuntu-Light", "NotoEmoji-Regular", "emoji-icon-font"]
-    // does not support CJK. Add them for Mac.
-    FontDefinitions::default()
+    load_cjk_fonts(&[
+        (
+            "/System/Library/Fonts/AppleSDGothicNeo.ttc",
+            "Apple SD Gothic Neo",
+        ), // Korean
+        ("/System/Library/Fonts/STHeiti Medium.ttc", "STHeiti Medium"), // Chinese + Japanese
+    ])
 }
 
 impl Drop for Gui {


### PR DESCRIPTION
Configure egui fonts for MacOS by loading CJK font files from standard system font paths.

Testing: Automated test is not possible. Run `./mach run -r -- ./cjk_test.html` on MacOS and see the tab title.  cjk_test.html's content is as follows
```html
<!DOCTYPE html>
<html>
<head>
<title>ご利用ガイド - 경애하는</title>
</head>
<body>
<p>Test</p>
</body>
</html>
```
Before: 
<img width="315" height="131" alt="螢幕快照 2026-09-13 於 14 04 05 下午" src="https://github.com/user-attachments/assets/fb398fac-eaaa-42bb-89c5-8cccb2df0df8" />
After:
<img width="328" height="131" alt="螢幕快照 2026-09-13 於 15 00 37 下午" src="https://github.com/user-attachments/assets/13811e12-42f4-48e9-864d-c3fcd348a3ef" />

Fixes: [#44066](https://github.com/servo/servo/issues/44066)
